### PR TITLE
Fix queries list parsed incorrectly for Java client

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -179,6 +179,7 @@ router.get(
       ctx.body = ((e.message || '').match(
         /(KnownQueryTypes|knownTypes)=\[(.*)\]/
       ) || [null, null, ''])[2]
+        .replace(',', '')
         .split(' ')
         .filter((q) => q);
     }


### PR DESCRIPTION
Fixes #54 

There is currently no endpoint to get the list of Queries from server. 
So to get the list of available queries, the code was making a dummy Query request and getting back an error message. The error message would contain the list of available queries which were getting parsed. In case of Java the error message is different than the Go error message. The parsing was broken for Java error message.
As a fix just modified the parsing

Also adding an actual API to query a list of available queries is "tracked" back to 2017 https://github.com/uber/cadence/issues/382