### PR TITLE
Fix submodules automatically updating to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,18 @@
 $(VERBOSE).SILENT:
 
 # default target
-default: update-proto-submodule
+default: init
 
 # git submodule for proto files
 
 update-proto-submodule:
-	git submodule update --init --remote $(PROTO_ROOT)
+	@printf $(COLOR) "Update temporal-api submodule from remote..."
+	git submodule update --force --remote $(PROTO_ROOT)
+
+install-proto-submodule:
+	@printf $(COLOR) "Install temporal-api submodule..."
+	git submodule update --init $(PROTO_ROOT)
+
+init: install-proto-submodule
+
+update: update-proto-submodule


### PR DESCRIPTION
Splits the submodule update script into two separate items:

`init`: pulls submodules according to the recorded submodule HEAD tag
`update`:  pulls the latest submodule and updates the submodule HEAD tag