### PR TITLE
Allow write methods only if opted-in via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ This web UI is used to view workflows from [Temporalio][temporal], see what's ru
 
 Set these environment variables if you need to change their defaults
 
-| Variable                      | Description                                    | Default        |
-| ----------------------------- | ---------------------------------------------- | -------------- |
-| TEMPORAL_GRPC_ENDPOINT        | String representing server gRPC endpoint       | 127.0.0.1:7233 |
-| TEMPORAL_WEB_PORT             | HTTP port to serve on                          | 8088           |
-| TEMPORAL_HOT_RELOAD_PORT      | HTTP port used by hot reloading in development | 8081           |
-| TEMPORAL_HOT_RELOAD_TEST_PORT | HTTP port used by hot reloading in tests       | 8082           |
-| TEMPORAL_EXTERNAL_SCRIPTS     | Addtional JavaScript tags to serve in the UI   |                |
+| Variable                      | Description                                                       | Default        |
+| ----------------------------- | ----------------------------------------------------------------- | -------------- |
+| TEMPORAL_GRPC_ENDPOINT        | String representing server gRPC endpoint                          | 127.0.0.1:7233 |
+| TEMPORAL_WEB_PORT             | HTTP port to serve on                                             | 8088           |
+| TEMPORAL_PERMIT_WRITE_API     | Boolean to permit write API methods such as Terminating Workflows | false          |
+| TEMPORAL_HOT_RELOAD_PORT      | HTTP port used by hot reloading in development                    | 8081           |
+| TEMPORAL_HOT_RELOAD_TEST_PORT | HTTP port used by hot reloading in tests                          | 8082           |
+| TEMPORAL_EXTERNAL_SCRIPTS     | Addtional JavaScript tags to serve in the UI                      |                |
 
 ### Running locally
 
@@ -48,18 +49,19 @@ All options are optional.
 For example, here is how you would add a request count metric using `uber-statsd-client`:
 
 ```javascript
-var app = require('temporal-web')
-var createStatsd = require('uber-statsd-client')
+var app = require('temporal-web');
+var createStatsd = require('uber-statsd-client');
 var sdc = createStatsd({
-    host: 'statsd.example.com'
-})
+  host: 'statsd.example.com',
+});
 
-app.use(async function(ctx, next) {
-  sdc.increment('http.request')
-  await next()
-})
-.init()
-.listen(7000)
+app
+  .use(async function(ctx, next) {
+    sdc.increment('http.request');
+    await next();
+  })
+  .init()
+  .listen(7000);
 ```
 
 The [webpack](https://webpack.js.org/) configuration is also exported as `webpackConfig`, and can be modified before calling `init()`.

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -1,11 +1,11 @@
 <template>
   <section class="workflow-summary">
-    <aside class="actions" v-if="showTerminate">
+    <aside class="actions">
       <feature-flag name="workflow-terminate">
         <a
           href=""
           class="terminate"
-          v-show="isWorkflowRunning"
+          v-show="showTerminate"
           @click.prevent="$modal.show('confirm-termination')"
         >
           Terminate
@@ -141,8 +141,6 @@ export default {
   data() {
     return {
       terminationReason: undefined,
-      showTerminate:
-        process.env.VUE_APP_ALLOW_WRITING === 'true' ? true : false,
     };
   },
   props: [
@@ -190,6 +188,9 @@ export default {
       }
 
       return this.result;
+    },
+    showTerminate() {
+      return this.isWorkflowRunning && process.env.VUE_APP_ALLOW_WRITING;
     },
   },
   methods: {

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="workflow-summary">
-    <aside class="actions">
+    <aside class="actions" v-if="showTerminate">
       <feature-flag name="workflow-terminate">
         <a
           href=""
@@ -141,6 +141,8 @@ export default {
   data() {
     return {
       terminationReason: undefined,
+      showTerminate:
+        process.env.VUE_APP_ALLOW_WRITING === 'true' ? true : false,
     };
   },
   props: [

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -190,7 +190,7 @@ export default {
       return this.result;
     },
     showTerminate() {
-      return this.isWorkflowRunning && process.env.VUE_APP_ALLOW_WRITING;
+      return this.isWorkflowRunning && process.env.VUE_APP_PERMIT_WRITE_API;
     },
   },
   methods: {

--- a/server/middleware/workflow-client.js
+++ b/server/middleware/workflow-client.js
@@ -5,7 +5,7 @@ const Long = require('long');
 const losslessJSON = require('lossless-json');
 const moment = require('moment');
 
-const _allowWrite = process.env.TEMPORAL_ALLOW_WRITING === 'true';
+const _permitWrite = process.env.TEMPORAL_PERMIT_WRITE_API === 'true';
 
 function buildHistory(getHistoryRes) {
   const history = getHistoryRes.history;
@@ -407,7 +407,7 @@ WorkflowClient.prototype.terminateWorkflow = async function({
   execution,
   reason,
 }) {
-  if (!_allowWrite) {
+  if (!_permitWrite) {
     throw Error('Terminate method is disabled');
   }
 

--- a/server/middleware/workflow-client.js
+++ b/server/middleware/workflow-client.js
@@ -5,6 +5,8 @@ const Long = require('long');
 const losslessJSON = require('lossless-json');
 const moment = require('moment');
 
+const _allowWrite = process.env.TEMPORAL_ALLOW_WRITING === 'true';
+
 function buildHistory(getHistoryRes) {
   const history = getHistoryRes.history;
 
@@ -405,6 +407,10 @@ WorkflowClient.prototype.terminateWorkflow = async function({
   execution,
   reason,
 }) {
+  if (!_allowWrite) {
+    throw Error('Terminate method is disabled');
+  }
+
   const req = {
     namespace,
     workflowExecution: buildWorkflowExecutionRequest(execution),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,31 +1,42 @@
-const
-  path = require('path'),
+const path = require('path'),
   webpack = require('webpack'),
   ExtractTextPlugin = require('extract-text-webpack-plugin'),
   HtmlWebpackPlugin = require('html-webpack-plugin'),
   extractStylus = 'css-loader?sourceMap!stylus-loader',
-  development = !['production', 'ci'].includes(process.env.NODE_ENV)
+  development = !['production', 'ci'].includes(process.env.NODE_ENV);
 
 require('babel-polyfill');
+
+const envKeys = {
+  VUE_APP_ALLOW_WRITING: process.env.TEMPORAL_ALLOW_WRITING,
+};
+
+if (!development) {
+  envKeys['NODE_ENV'] = '"production"';
+}
 
 module.exports = {
   devtool: 'source-map',
   entry: [
     'babel-polyfill',
-    path.join(__dirname, process.env.TEST_RUN ? 'client/test/index' : 'client/main')
-  ].filter(x => x),
+    path.join(
+      __dirname,
+      process.env.TEST_RUN ? 'client/test/index' : 'client/main'
+    ),
+  ].filter((x) => x),
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'temporal.[hash].js',
-    publicPath: '/'
+    publicPath: '/',
   },
   plugins: [
-    !development && new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: '"production"'
-      }
+    new webpack.DefinePlugin({
+      'process.env': envKeys,
     }),
-    new ExtractTextPlugin({ filename: development ? 'temporal.css' : 'temporal.[hash].css', allChunks: true }),
+    new ExtractTextPlugin({
+      filename: development ? 'temporal.css' : 'temporal.[hash].css',
+      allChunks: true,
+    }),
     new HtmlWebpackPlugin({
       title: 'Temporal',
       filename: 'index.html',
@@ -33,9 +44,11 @@ module.exports = {
       inject: false,
       template: require('html-webpack-template'),
       lang: 'en-US',
-      scripts: (process.env.TEMPORAL_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)
-    })
-  ].filter(x => x),
+      scripts: (process.env.TEMPORAL_EXTERNAL_SCRIPTS || '')
+        .split(',')
+        .filter((x) => x),
+    }),
+  ].filter((x) => x),
   module: {
     rules: [
       {
@@ -58,42 +71,47 @@ module.exports = {
             },
             stylus: ExtractTextPlugin.extract({
               use: extractStylus,
-              fallback: 'vue-style-loader'
+              fallback: 'vue-style-loader',
             }),
-          }
-        }
+          },
+        },
       },
       {
         test: /\.svg$/,
-        use: [{
-          loader: 'html-loader',
-          options: {
-            minimize: true
-          }
-        }]
+        use: [
+          {
+            loader: 'html-loader',
+            options: {
+              minimize: true,
+            },
+          },
+        ],
       },
       {
         test: /\.(png|jpg|gif)$/,
         loader: 'file-loader',
         options: {
-          name: '[name].[ext]?[hash]'
-        }
+          name: '[name].[ext]?[hash]',
+        },
       },
       {
         test: /\.styl$/,
-        use: ExtractTextPlugin.extract({ use: extractStylus, fallback: 'raw-loader' }),
-        include: path.join(__dirname, 'src')
-      }
-    ]
+        use: ExtractTextPlugin.extract({
+          use: extractStylus,
+          fallback: 'raw-loader',
+        }),
+        include: path.join(__dirname, 'src'),
+      },
+    ],
   },
   resolve: {
     alias: {
-      'vue$': 'vue/dist/vue.esm.js',
+      vue$: 'vue/dist/vue.esm.js',
     },
-    extensions: ['*', '.js', '.vue', '.json']
+    extensions: ['*', '.js', '.vue', '.json'],
   },
   devServer: {
     historyApiFallback: true,
-    overlay: true
-  }
-}
+    overlay: true,
+  },
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,8 @@ const path = require('path'),
 require('babel-polyfill');
 
 const envKeys = {
-  VUE_APP_ALLOW_WRITING: [true, 'true'].includes(
-    process.env.TEMPORAL_ALLOW_WRITING
+  VUE_APP_PERMIT_WRITE_API: [true, 'true'].includes(
+    process.env.TEMPORAL_PERMIT_WRITE_API
   ),
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,9 @@ const path = require('path'),
 require('babel-polyfill');
 
 const envKeys = {
-  VUE_APP_ALLOW_WRITING: process.env.TEMPORAL_ALLOW_WRITING,
+  VUE_APP_ALLOW_WRITING: [true, 'true'].includes(
+    process.env.TEMPORAL_ALLOW_WRITING
+  ),
 };
 
 if (!development) {


### PR DESCRIPTION
- By default Terminate and write APIs are disabled for security reasons
- Added TEMPORAL_PERMIT_WRITE_API env variable to permit terminating workflows (and other write APIs)
- Removed Terminate button unless opted-in