### PR TITLE
Refactor permitting write api to account for docker variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Set these environment variables if you need to change their defaults
 | ----------------------------- | ----------------------------------------------------------------- | -------------- |
 | TEMPORAL_GRPC_ENDPOINT        | String representing server gRPC endpoint                          | 127.0.0.1:7233 |
 | TEMPORAL_WEB_PORT             | HTTP port to serve on                                             | 8088           |
-| TEMPORAL_PERMIT_WRITE_API     | Boolean to permit write API methods such as Terminating Workflows | false          |
+| TEMPORAL_PERMIT_WRITE_API     | Boolean to permit write API methods such as Terminating Workflows | true           |
 | TEMPORAL_HOT_RELOAD_PORT      | HTTP port used by hot reloading in development                    | 8081           |
 | TEMPORAL_HOT_RELOAD_TEST_PORT | HTTP port used by hot reloading in tests                          | 8082           |
 | TEMPORAL_EXTERNAL_SCRIPTS     | Addtional JavaScript tags to serve in the UI                      |                |

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -160,6 +160,10 @@ export default {
     'detail-list': DetailList,
     'feature-flag': FeatureFlag,
   },
+  created() {
+    this.namespaceDescCache = {};
+    this.getWebSettings()
+  },
   computed: {
     workflowCloseTime() {
       return this.workflow.workflowExecutionInfo.closeTime
@@ -190,7 +194,7 @@ export default {
       return this.result;
     },
     showTerminate() {
-      return this.isWorkflowRunning && process.env.VUE_APP_PERMIT_WRITE_API;
+      return this.isWorkflowRunning && this.webSettingsCache.permitWriteApi;
     },
   },
   methods: {
@@ -216,6 +220,16 @@ export default {
             });
           }
         );
+    },
+    getWebSettings() {
+      if (this.webSettingsCache) {
+        return Promise.resolve(this.webSettingsCache);
+      }
+
+      return this.$http(`/api/web-settings`).then((r) => {
+        this.webSettingsCache = r;
+        return this.webSettingsCache;
+      });
     },
   },
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -4,7 +4,8 @@ const Router = require('koa-router'),
   Long = require('long'),
   losslessJSON = require('lossless-json'),
   momentToLong = (m) => Long.fromValue(m.unix()).mul(1000000000),
-  WorkflowClient = require('./middleware/workflow-client');
+  WorkflowClient = require('./workflow-client'),
+  utils = require('./utils');
 
 const wfClient = new WorkflowClient();
 
@@ -322,6 +323,11 @@ router.get(
   }
 );
 
-router.get('/health', (ctx) => (ctx.body = 'OK'));
+router.get('/api/web-settings', (ctx) => {
+  ctx.body = {
+    health: 'OK',
+    permitWriteApi: utils.isWriteApiPermitted(),
+  };
+});
 
 module.exports = router;

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,0 +1,5 @@
+const isWriteApiPermitted = () => {
+  return ![false, 'false'].includes(process.env.TEMPORAL_PERMIT_WRITE_API);
+};
+
+module.exports = { isWriteApiPermitted };

--- a/server/workflow-client.js
+++ b/server/workflow-client.js
@@ -4,8 +4,7 @@ const protoLoader = require('@grpc/proto-loader');
 const Long = require('long');
 const losslessJSON = require('lossless-json');
 const moment = require('moment');
-
-const _permitWrite = process.env.TEMPORAL_PERMIT_WRITE_API === 'true';
+const utils = require('./utils');
 
 function buildHistory(getHistoryRes) {
   const history = getHistoryRes.history;
@@ -428,7 +427,7 @@ WorkflowClient.prototype.terminateWorkflow = async function({
   execution,
   reason,
 }) {
-  if (!_permitWrite) {
+  if (!utils.isWriteApiPermitted()) {
     throw Error('Terminate method is disabled');
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,7 @@ const path = require('path'),
 require('babel-polyfill');
 
 const envKeys = {
-  VUE_APP_PERMIT_WRITE_API: [true, 'true'].includes(
-    process.env.TEMPORAL_PERMIT_WRITE_API
-  ),
 };
-
 if (!development) {
   envKeys['NODE_ENV'] = '"production"';
 }


### PR DESCRIPTION
- Reads env variable `TEMPORAL_PERMIT_WRITE_API` at runtime instead of build time
- Reads the variable as `true` by default, unless clearly set to `false`

Related PR https://github.com/temporalio/temporal/pull/656