### PR TITLE
Fix navigation to summary page

### DIFF
--- a/client/routes/workflow/history.vue
+++ b/client/routes/workflow/history.vue
@@ -6,6 +6,7 @@
       'has-results': !!events.length,
       'split-enabled': true,
     }"
+    data-cy="history"
   >
     <header class="controls">
       <div class="view-format">

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -6,12 +6,14 @@
         icon="icon_receipt"
         label="Summary"
         :to="{ name: 'workflow/summary' }"
+        data-cy="summary-link"
       />
       <navigation-link
         id="nav-link-history"
         icon="icon_trip-history"
         label="History"
         :to="{ name: 'workflow/history' }"
+        data-cy="history-link"
       />
       <navigation-link
         id="nav-link-stack-trace"
@@ -19,6 +21,7 @@
         label="Stack Trace"
         :to="{ name: 'workflow/stack-trace' }"
         v-show="isWorkflowRunning"
+        data-cy="stack-trace-link"
       />
       <navigation-link
         id="nav-link-query"
@@ -26,6 +29,7 @@
         label="Query"
         :to="{ name: 'workflow/query' }"
         v-show="isWorkflowRunning"
+        data-cy="query-link"
       />
     </navigation-bar>
     <router-view

--- a/client/routes/workflow/query.vue
+++ b/client/routes/workflow/query.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="query" :class="{ loading }">
+  <section class="query" :class="{ loading }" data-cy="query">
     <header v-if="queries && queries.length">
       <div class="query-name">
         <v-select

--- a/client/routes/workflow/stack-trace.vue
+++ b/client/routes/workflow/stack-trace.vue
@@ -1,5 +1,5 @@
 <template>
-  <section :class="{ 'stack-trace': true, loading }">
+  <section :class="{ 'stack-trace': true, loading }" data-cy="stack-trace">
     <header v-if="stackTraceTimestamp">
       <span>Stack trace at {{ stackTraceTimestamp.format('h:mm:ss a') }}</span>
       <a href="#" class="refresh" @click="getStackTrace">Refresh</a>

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="workflow-summary">
+  <section class="workflow-summary" data-cy="summary">
     <aside class="actions">
       <feature-flag name="workflow-terminate">
         <a
@@ -150,6 +150,7 @@ export default {
   data() {
     return {
       terminationReason: undefined,
+      webSettingsCache: undefined
     };
   },
   props: [
@@ -203,7 +204,7 @@ export default {
       return this.result;
     },
     showTerminate() {
-      return this.isWorkflowRunning && this.webSettingsCache.permitWriteApi;
+      return this.isWorkflowRunning && this.webSettingsCache?.permitWriteApi;
     },
   },
   methods: {

--- a/cypress/integration/workflow-details.spec.js
+++ b/cypress/integration/workflow-details.spec.js
@@ -1,0 +1,25 @@
+/// <reference types="cypress" />
+
+context('Workflow Details', () => {
+  beforeEach(() => {
+    cy.visit('/namespaces/namespace-web-e2e/workflows?range=last-5-days&status=OPEN');
+
+    cy.get('[data-cy=workflow-list]')
+      .find('tr')
+      .eq(0)
+      .find('[data-cy=workflow-link]')
+      .click();
+    cy.url().should('include', '/summary');
+  });
+
+  it('navigates between summary/history/../query tabs', () => {
+    cy.get('[data-cy=history-link]').click()
+    cy.get('[data-cy=history]')
+    cy.get('[data-cy=stack-trace-link]').click()
+    cy.get('[data-cy=stack-trace]')
+    cy.get('[data-cy=query-link]').click()
+    cy.get('[data-cy=query]')
+    cy.get('[data-cy=summary-link]').click()
+    cy.get('[data-cy=summary]').should('contain.text', 'Workflow Name')
+  });
+});


### PR DESCRIPTION
There was an issue with Open workflows when if you go from History page to Summary, summary would be shown empty
![image](https://user-images.githubusercontent.com/11838981/92050670-82b86080-ed41-11ea-8ae6-d456e495cff1.png)

