### PR TITLE
Improve rendering of failure messages

### DIFF
--- a/client/components/data-viewer.vue
+++ b/client/components/data-viewer.vue
@@ -5,12 +5,7 @@
       class="view-full-screen"
       @click.stop.prevent="viewFullScreen"
     ></a>
-    <prism v-if="highlight !== false" language="json" ref="codebox">{{
-      item.jsonStringDisplay
-    }}</prism>
-    <pre v-if="highlight === false" ref="codebox">{{
-      item.jsonStringDisplay
-    }}</pre>
+    <prism language="json" ref="codebox">{{ dataPreview }}</prism>
   </div>
 </template>
 
@@ -33,22 +28,33 @@ export default {
         return;
       }
 
-      const action =
+      const hasMoreJson =
+        this.item.jsonStringFull.length > this.item.jsonStringDisplay.length;
+
+      const overflowed =
         el.scrollWidth > el.offsetWidth + 2 ||
-        el.scrollHeight > el.offsetHeight + 2
-          ? 'add'
-          : 'remove';
+        el.scrollHeight > el.offsetHeight + 2;
+
+      const action = hasMoreJson || overflowed ? 'add' : 'remove';
 
       this.$el.classList[action]('overflow');
     };
     window.addEventListener('resize', this.checkOverflow);
-    ['item', 'highlight', 'compact'].forEach(e =>
+    ['item', 'highlight', 'compact'].forEach((e) =>
       this.$watch(e, this.checkOverflow)
     );
     this.$watch(() => this.$route, this.checkOverflow);
   },
   mounted() {
     this.checkOverflow();
+  },
+  computed: {
+    dataPreview() {
+      return this.item.jsonStringDisplay;
+    },
+    dataFullview() {
+      return JSON.tryParse(this.item.jsonStringFull);
+    },
   },
   beforeDestroy() {
     window.removeEventListener('resize', this.checkOverflow);
@@ -71,7 +77,7 @@ export default {
           `,
         },
         {
-          code: this.item.jsonStringFull,
+          code: this.dataFullview,
           title: this.title,
         },
         {

--- a/client/constants.js
+++ b/client/constants.js
@@ -1,4 +1,4 @@
-export const jsonKeys = ['result', 'input', 'details', 'data', 'Error'];
+export const jsonKeys = ['result', 'input', 'details', 'data', 'failure'];
 export const preKeys = jsonKeys.concat(['stackTrace', 'details.stackTrace']);
 
 export const ENVIRONMENT_LIST = [
@@ -24,9 +24,9 @@ export const ENVIRONMENT_LIST = [
   // },
 ];
 
-export const MAXIMUM_JSON_CHARACTER_LIMIT = 5000;
+export const MAXIMUM_JSON_CHARACTER_LIMIT = 100;
 export const MAXIMUM_JSON_MESSAGE =
-  '\n ... to see more open full screen mode from top right arrow.';
+  '\n * to see more open full screen mode from top right arrow.';
 
 export const NOTIFICATION_TYPE_ERROR = 'error';
 export const NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT =

--- a/client/helpers/get-key-value-pairs.js
+++ b/client/helpers/get-key-value-pairs.js
@@ -73,6 +73,19 @@ const getKeyValuePairs = (event) => {
           },
           value,
         });
+      } else if (key === 'failure') {
+        let node = { ...value };
+        let failure = '';
+        let isRoot = true;
+        while (node) {
+          const { message, stackTrace, source } = node;
+          failure += isRoot
+            ? `${source} ${message}\n${stackTrace}`
+            : `\nCaused By: ${source} ${message}\n${stackTrace}`;
+          node = node.cause;
+          isRoot = false;
+        }
+        kvps.push({ key, value: getJsonStringObject(failure) });
       } else if (preKeys.includes(k)) {
         kvps.push({
           key,

--- a/client/helpers/get-string-elipsis.js
+++ b/client/helpers/get-string-elipsis.js
@@ -1,7 +1,7 @@
 import { MAXIMUM_JSON_CHARACTER_LIMIT, MAXIMUM_JSON_MESSAGE } from '~constants';
 
 const getStringElipsis = (input) =>
-  input.length < MAXIMUM_JSON_CHARACTER_LIMIT
+  input.length <= MAXIMUM_JSON_CHARACTER_LIMIT
     ? input
     : `${input.substring(
         0,

--- a/client/helpers/get-string-elipsis.js
+++ b/client/helpers/get-string-elipsis.js
@@ -1,8 +1,11 @@
 import { MAXIMUM_JSON_CHARACTER_LIMIT, MAXIMUM_JSON_MESSAGE } from '~constants';
 
-const getStringElipsis = input =>
+const getStringElipsis = (input) =>
   input.length < MAXIMUM_JSON_CHARACTER_LIMIT
     ? input
-    : input.substring(0, MAXIMUM_JSON_CHARACTER_LIMIT) + MAXIMUM_JSON_MESSAGE;
+    : `${input.substring(
+        0,
+        MAXIMUM_JSON_CHARACTER_LIMIT
+      )}... ${MAXIMUM_JSON_MESSAGE}`;
 
 export default getStringElipsis;

--- a/client/helpers/get-string-elipsis.spec.js
+++ b/client/helpers/get-string-elipsis.spec.js
@@ -15,7 +15,20 @@ describe('getStringElipsis', () => {
       const input = ''.padEnd(MAXIMUM_JSON_CHARACTER_LIMIT, '_');
       const output = getStringElipsis(input);
 
-      expect(output).toEqual(input + MAXIMUM_JSON_MESSAGE);
+      expect(output).toEqual(input);
+    });
+  });
+
+  describe('when passed a string that has a length greater than MAXIMUM_JSON_CHARACTER_LIMIT', () => {
+    it('should return a substring of the original string up until the limit and display a message.', () => {
+      const input = ''.padEnd(MAXIMUM_JSON_CHARACTER_LIMIT + 1, '_');
+      const output = getStringElipsis(input);
+
+      const expected =
+        ''.padEnd(MAXIMUM_JSON_CHARACTER_LIMIT, '_') +
+        '... ' +
+        MAXIMUM_JSON_MESSAGE;
+      expect(output).toEqual(expected);
     });
   });
 });

--- a/client/routes/workflow/helpers/summarize-events.js
+++ b/client/routes/workflow/helpers/summarize-events.js
@@ -117,6 +117,12 @@ const summaryExtractors = {
   WorkflowExecutionFailed: (d) => {
     return { message: d.failure.message };
   },
+  WorkflowTaskFailed: (d) => {
+    return { message: d.failure.message };
+  },
+  ChildWorkflowExecutionFailed: (d) => {
+    return { message: d.failure.message };
+  },
 };
 
 const isKnownEventType = (eventType) => {


### PR DESCRIPTION
for this Error structure:
![image](https://user-images.githubusercontent.com/11838981/92288581-30eb1400-eec2-11ea-83ec-141ed69db78a.png)

the resulting views:

## Grid -> Summary

![image](https://user-images.githubusercontent.com/11838981/92287566-f92e9d00-eebe-11ea-91db-1facc3e5813a.png)

## Grid -> Full details (not expanded)

![image](https://user-images.githubusercontent.com/11838981/92288504-f71a0d80-eec1-11ea-8382-ce9433a61660.png)

## Grid -> Full details (expanded)

![image](https://user-images.githubusercontent.com/11838981/92288520-04cf9300-eec2-11ea-9cdb-86fdf1106051.png)
