### PR TITLE
Clean up heartbeats message from payloads.0 wording

### DIFF
--- a/client/constants.js
+++ b/client/constants.js
@@ -3,6 +3,7 @@ export const jsonKeys = [
   'result',
   'input',
   'details',
+  'heartbeatDetails',
   'data',
   'payloads',
 ];


### PR DESCRIPTION
before it would say `heartbeats.payloads.0`

![image](https://user-images.githubusercontent.com/11838981/93963300-a4d64a80-fd11-11ea-9c7a-264c4dcbdae8.png)

