### PR TITLE
Render failure message for ActivityTaskTimedOut in summary view

### DIFF
--- a/client/routes/workflow/helpers/summarize-events.js
+++ b/client/routes/workflow/helpers/summarize-events.js
@@ -23,7 +23,7 @@ const summaryExtractors = {
     identity: d.identity,
     requestId: d.requestId,
   }),
-  ActivityTaskTimedOut: (d) => ({ 'Timeout Type': d.timeoutType }),
+  ActivityTaskTimedOut: (d) => ({ message: d.failure?.cause?.message }),
   ChildWorkflowExecutionCompleted: (d) => ({
     result: d.result,
     Workflow: workflowLink(d, true),
@@ -114,15 +114,9 @@ const summaryExtractors = {
 
     return summary;
   },
-  WorkflowExecutionFailed: (d) => {
-    return { message: d.failure.message };
-  },
-  WorkflowTaskFailed: (d) => {
-    return { message: d.failure.message };
-  },
-  ChildWorkflowExecutionFailed: (d) => {
-    return { message: d.failure.message };
-  },
+  WorkflowExecutionFailed: (d) => ({ message: d.failure?.message }),
+  WorkflowTaskFailed: (d) => ({ message: d.failure?.message }),
+  ChildWorkflowExecutionFailed: (d) => ({ message: d.failure?.message }),
 };
 
 const isKnownEventType = (eventType) => {


### PR DESCRIPTION
## before:
![image](https://user-images.githubusercontent.com/11838981/93963373-dd762400-fd11-11ea-9fd0-1ab6596d077e.png)

## after:
![image](https://user-images.githubusercontent.com/11838981/94213749-88aae880-fe8c-11ea-9998-a0ed928b0832.png)

