### PR TITLE
Set json preview to max of 8 lines

### DIFF
--- a/client/components/detail-list.vue
+++ b/client/components/detail-list.vue
@@ -30,7 +30,7 @@ export default {
               props: {
                 item: kvp.value,
                 title: `${title} - ${kvp.key}`,
-                maxLines: 3,
+                maxLines: 8,
               },
             }),
           ]


### PR DESCRIPTION
in the case below `input` and other json previews will take up to 8 lines by default
![image](https://user-images.githubusercontent.com/11838981/94220992-17c0fc00-fe9f-11ea-8e15-c2276a53e1f3.png)
 