### PR TITLE
Always show Stack Trace and Query pages

### DIFF
--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -20,7 +20,6 @@
         icon="icon_trips"
         label="Stack Trace"
         :to="{ name: 'workflow/stack-trace' }"
-        v-show="isWorkflowRunning"
         data-cy="stack-trace-link"
       />
       <navigation-link
@@ -28,7 +27,6 @@
         icon="icon_lost"
         label="Query"
         :to="{ name: 'workflow/query' }"
-        v-show="isWorkflowRunning"
         data-cy="query-link"
       />
     </navigation-bar>


### PR DESCRIPTION
There was a recent enough change that made Stack Trace and Query pages notify when there is no worker running. 
The current PR makes these pages always visible

![image](https://user-images.githubusercontent.com/11838981/97392062-086a0f80-189e-11eb-8553-4336302370d8.png)
