### PR TITLE
Fix possible duplication of workflow instance in ALL view

### DIFF
--- a/client/routes/namespace/workflow-list.vue
+++ b/client/routes/namespace/workflow-list.vue
@@ -327,10 +327,13 @@ export default {
           maxOpen = moment(maxOpen.startTime);
           maxClosed = moment(maxClosed.startTime);
           saturateOpen = maxOpen < maxClosed;
-          const [startDate, endDate] = saturateOpen
-            ? [maxOpen.startTime, maxClosed.startTime]
-            : [maxClosed.startTime, maxOpen.startTime];
-          const queryDiff = { ...this.criteria, startDate, endDate };
+
+          let [startTime, endTime] = saturateOpen
+            ? [maxOpen, maxClosed]
+            : [maxClosed, maxOpen];
+          startTime = startTime.add(1, 'milliseconds').toISOString();
+          endTime = startTime.add(1, 'milliseconds').toISOString();
+          const queryDiff = { ...this.criteria, startTime, endTime };
 
           let diff = await this.fetch(
             `/api/namespaces/${namespace}/workflows/${


### PR DESCRIPTION
in ALL workflows view it is possible that a workflow would be duplicated in the view as the diff fetch was starting from the time of the last workflow. This last workflow could be duplicated. Made the fetch to start from the next smallest time interval (millisecond as of momentum js)