### PR TITLE
Add customization of auth scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enabl
     auth:
       enabled: true # Temporal Web checks this first before reading your provider config
       providers:
-          - label: 'googleoidc'
+          - label: 'google oidc'
             type: oidc
             issuer: https://accounts.google.com
             client_id: xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
             client_secret: xxxxxxxxxxxxxxxxxxxxxxx
+            scope: openid profile email
             callback_base_uri: http://localhost:8088
     ```
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enabl
     auth:
       enabled: true # Temporal Web checks this first before reading your provider config
       providers:
-          - label: 'google oidc'
-            type: oidc
+          - label: 'google oidc'                        # for internal use; in future may expose as button text
+            type: oidc                                  # for futureproofing; only oidc is supported today
             issuer: https://accounts.google.com
             client_id: xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
             client_secret: xxxxxxxxxxxxxxxxxxxxxxx

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -20,12 +20,14 @@ const initialize = async (ctx, next) => {
       issuer,
       client_id: clientId,
       client_secret: clientSecret,
+      scope,
       callback_base_uri: callbackUri,
     } = auth.providers[0]; // we currently support single auth config
     const strategy = await oidc.getStrategy(
       issuer,
       clientId,
       clientSecret,
+      scope || 'openid profile email',
       callbackUri
     );
     passport.use(STRATEGY_NAMES.oidc, strategy);

--- a/server/auth/oidc.js
+++ b/server/auth/oidc.js
@@ -21,6 +21,7 @@ const getStrategy = async (
   issuerUrl,
   clientId,
   clientSecret,
+  scope,
   callbackUriBase
 ) => {
   const client = await getClient(
@@ -30,7 +31,7 @@ const getStrategy = async (
     callbackUriBase
   );
   const params = {
-    scope: 'openid profile email',
+    scope,
     response: ['userinfo'],
   };
 

--- a/server/config.yml
+++ b/server/config.yml
@@ -2,8 +2,8 @@ auth:
   enabled: false
   providers:
       # # example provider
-      # - label: 'googleoidc'
-      #   type: oidc
+      # - label: 'google oidc'                        # for internal use; in future may expose as button text
+      #   type: oidc                                  # for futureproofing; only oidc is supported today
       #   issuer: https://accounts.google.com
       #   client_id: xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
       #   client_secret: xxxxxxxxxxxxxxxxxxxxxxx

--- a/server/config.yml
+++ b/server/config.yml
@@ -7,4 +7,5 @@ auth:
       #   issuer: https://accounts.google.com
       #   client_id: xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
       #   client_secret: xxxxxxxxxxxxxxxxxxxxxxx
+      #   scope: openid profile email
       #   callback_base_uri: http://localhost:8088

--- a/server/config.yml
+++ b/server/config.yml
@@ -9,3 +9,5 @@ auth:
       #   client_secret: xxxxxxxxxxxxxxxxxxxxxxx
       #   scope: openid profile email
       #   callback_base_uri: http://localhost:8088
+
+# for more info see docs: https://github.com/temporalio/web#configuring-authentication-optional


### PR DESCRIPTION
Some oidc providers may not have profile/email scopes and instead have something else. This pr allows to customize the scopes.
In addition this can also be used to specify the custom claims for AuthZ 