### PR TITLE
Add support to pass oauth audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enabl
             client_id: xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
             client_secret: xxxxxxxxxxxxxxxxxxxxxxx
             scope: openid profile email
+            audience: temporal # identifier of the audience for an issued token (optional)
             callback_base_uri: http://localhost:8088
     ```
 

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -21,6 +21,7 @@ const initialize = async (ctx, next) => {
       client_id: clientId,
       client_secret: clientSecret,
       scope,
+      audience,
       callback_base_uri: callbackUri,
     } = auth.providers[0]; // we currently support single auth config
     const strategy = await oidc.getStrategy(
@@ -28,6 +29,7 @@ const initialize = async (ctx, next) => {
       clientId,
       clientSecret,
       scope || 'openid profile email',
+      audience,
       callbackUri
     );
     passport.use(STRATEGY_NAMES.oidc, strategy);

--- a/server/auth/oidc.js
+++ b/server/auth/oidc.js
@@ -24,6 +24,7 @@ const getStrategy = async (
   clientId,
   clientSecret,
   scope,
+  audience,
   callbackUriBase
 ) => {
   const client = await getClient(
@@ -34,6 +35,7 @@ const getStrategy = async (
   );
   const params = {
     scope,
+    audience,
     response: ['userinfo'],
   };
 


### PR DESCRIPTION
this typically allows to pass the App/API id that defines authz scopes

As an example, in Auth0 you create an API and define new Permissions (Scopes)
![image](https://user-images.githubusercontent.com/11838981/99858212-e0d73180-2b41-11eb-8b9e-5d83ea0559c0.png)

 