### PR TITLE
Add Okta configuration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enabl
     - Google: https://developers.google.com/identity/protocols/oauth2/openid-connect
     - Auth0: https://auth0.com/docs/protocols/configure-okta-as-oauth2-identity-provider
     - Okta: https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard_OIDC.htm
+        <details>
+          <summary>
+            Troubleshooting note for Okta users:
+          </summary>
+          Some providers like Okta, have a race condition that may cause logins to occasionally fail. You can get around this by providing the full URL to the `openid-configuration` path as part of the `issuer` parameter:
+
+              ```yaml
+              auth:
+                enabled: true
+                providers:
+                    - label: 'okta dev'
+                      type: oidc
+                      issuer: https://dev-xxxxxxx.okta.com/.well-known/openid-configuration
+                      ...
+            ```
+      </details>
     - Keycloak: https://www.keycloak.org/getting-started/getting-started-docker
     - please feel free to [PR or request more help on the Temporal Web repo](https://github.com/temporalio/web/)
 
@@ -147,6 +163,5 @@ The [webpack](https://webpack.js.org/) configuration is also exported as `webpac
 MIT License, please see [LICENSE](https://github.com/temporalio/temporal-web/blob/master/LICENSE) for details.
 
 [temporal]: https://github.com/temporalio/temporal
-
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftemporalio%2Ftemporal-web.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftemporalio%2Ftemporal-web?ref=badge_large)


### PR DESCRIPTION
Okta authentication behaves flaky as sometimes it works and other times doesn't.
Seems there is a race condition when discovering openid configuration endpoins. More details here https://github.com/panva/node-openid-client/issues/260

Added a readme note to explicitly configure the full discovery url that fixes the flakiness with Okta 