### PR TITLE
Add nonce to oidc auth strategy

### DIFF
--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -3,6 +3,7 @@ const passport = require('koa-passport');
 const oidc = require('./oidc');
 const { STRATEGY_NAMES } = require('./constants');
 const { getAuthConfig } = require('../config');
+const { generators } = require('openid-client');
 
 const initialize = async (ctx, next) => {
   const auth = await getAuthConfig();
@@ -47,7 +48,7 @@ const initialize = async (ctx, next) => {
 const authenticate = (ctx, next, options, callback) => {
   return passport.authenticate(
     STRATEGY_NAMES.oidc,
-    options,
+    { nonce: generators.nonce(), ...options },
     callback
   )(ctx, next);
 };

--- a/server/auth/oidc.js
+++ b/server/auth/oidc.js
@@ -8,6 +8,7 @@ async function getClient(issuerUrl, clientId, clientSecret, callbackUriBase) {
     redirect_uris: [`${callbackUriBase}/auth/sso_callback`],
     post_logout_redirect_uris: [`${callbackUriBase}/auth/logout_callback`],
     token_endpoint_auth_method: 'client_secret_post',
+    response_types: ['code'],
   });
 }
 


### PR DESCRIPTION
Adds support to "Sign in with Apple" SSO: https://developer.apple.com/sign-in-with-apple/

Apple's SSO docs do not mention OIDC, even though the sso follows oidc very closely. It adds a requirement of having nonce even in `code` flow.
Adding nonce doesn't contradict oidc `code` flow protocol, though not very common. Tested with Auth0 and "Sign in with Apple"