### PR TITLE
Fix auth redirection, some refactoring

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -115,7 +115,7 @@ export default {
       this.onVersionAnnouncementClose();
     },
     async getWebSettings() {
-      this.webSettings = await this.$http(`/api/web-settings`);
+      this.webSettings = await this.$http('/api/web-settings');
     },
     async getCurrentUser() {
       const me = await this.$http('/api/me');
@@ -124,22 +124,21 @@ export default {
     redirectIfApplicable() {
       const { auth, routing } = this.webSettings;
 
-      if (auth?.enabled) {
-        if (!this.currentUser) {
-          this.$router.push('/signin');
-          return;
-        }
+      if (auth?.enabled && !this.currentUser) {
+        this.$router.push('/signin');
+        return;
       }
-      if (routing?.defaultToNamespace) {
+      if (
+        routing?.defaultToNamespace &&
+        routing.defaultToNamespace !== this.$route.params.namespace
+      ) {
         const { defaultToNamespace } = routing;
-        if (defaultToNamespace !== this.$route.params.namespace) {
-          this.onNotification({
-            message: `No access to namespace ${this.$route.params.namespace}. Redirecting to ${defaultToNamespace}`,
-            type: NOTIFICATION_TYPE_ERROR,
-          });
-          this.$router.push(`/namespaces/${defaultToNamespace}/workflows`);
-          return;
-        }
+        this.onNotification({
+          message: `No access to namespace ${this.$route.params.namespace}. Redirecting to ${defaultToNamespace}`,
+          type: NOTIFICATION_TYPE_ERROR,
+        });
+        this.$router.push(`/namespaces/${defaultToNamespace}/workflows`);
+        return;
       }
     },
     async announceNewVersionIfExists() {

--- a/client/App.vue
+++ b/client/App.vue
@@ -59,6 +59,7 @@ export default {
         link: '',
       },
       onVersionAnnouncementClose: () => {},
+      webSettings: undefined,
       currentUser: undefined,
     };
   },
@@ -66,17 +67,9 @@ export default {
     clearTimeout(this.notification.timeout);
   },
   async created() {
-    const promises = [this.verifyAuth(), this.verifyNamespaceAccess()];
-    const { show, message, link, version } = await getNewVersionAnnouncement(
-      this.$http,
-      this.onNotification
-    );
-    this.announcement = { show, message, link };
-    if (version) {
-      this.onVersionAnnouncementClose = () =>
-        discardVersionAnnouncement(version);
-    }
-    await Promise.all(promises);
+    await Promise.all([this.getCurrentUser(), this.getWebSettings()]);
+    this.redirectIfApplicable();
+    await this.announceNewVersionIfExists();
   },
   methods: {
     globalClick(e) {
@@ -121,34 +114,43 @@ export default {
       this.announcement.show = false;
       this.onVersionAnnouncementClose();
     },
-    async verifyNamespaceAccess() {
-      if (!this.$route.params.namespace) {
-        return;
+    async getWebSettings() {
+      this.webSettings = await this.$http(`/api/web-settings`);
+    },
+    async getCurrentUser() {
+      const me = await this.$http('/api/me');
+      this.currentUser = me?.user;
+    },
+    redirectIfApplicable() {
+      const { auth, routing } = this.webSettings;
+
+      if (auth?.enabled) {
+        if (!this.currentUser) {
+          this.$router.push('/signin');
+          return;
+        }
       }
-
-      const { routingConfig } = await this.$http(`/api/web-settings`);
-      if (!routingConfig?.defaultToNamespace) {
-        return;
-      }
-
-      const { defaultToNamespace } = routingConfig;
-
-      if (defaultToNamespace !== this.$route.params.namespace) {
-        this.onNotification({
-          message: `No access to namespace ${this.$route.params.namespace}. Redirecting to ${defaultToNamespace}`,
-          type: NOTIFICATION_TYPE_ERROR,
-        });
-        this.$router.push(`/namespaces/${defaultToNamespace}/workflows`);
+      if (routing?.defaultToNamespace) {
+        const { defaultToNamespace } = routing;
+        if (defaultToNamespace !== this.$route.params.namespace) {
+          this.onNotification({
+            message: `No access to namespace ${this.$route.params.namespace}. Redirecting to ${defaultToNamespace}`,
+            type: NOTIFICATION_TYPE_ERROR,
+          });
+          this.$router.push(`/namespaces/${defaultToNamespace}/workflows`);
+          return;
+        }
       }
     },
-    async verifyAuth() {
-      const me = await this.$http('/api/me');
-      if (me.isAuthEnabled) {
-        if (!me.user) {
-          this.$router.push('/signin');
-        } else {
-          this.currentUser = me.user;
-        }
+    async announceNewVersionIfExists() {
+      const { show, message, link, version } = await getNewVersionAnnouncement(
+        this.$http,
+        this.onNotification
+      );
+      this.announcement = { show, message, link };
+      if (version) {
+        this.onVersionAnnouncementClose = () =>
+          discardVersionAnnouncement(version);
       }
     },
   },

--- a/client/components/namespace-navigation.vue
+++ b/client/components/namespace-navigation.vue
@@ -86,13 +86,6 @@ export default {
   async created() {
     this.namespaceDescCache = {};
 
-    const { routingConfig } = await this.$http(`/api/web-settings`);
-    if (routingConfig?.defaultToNamespace) {
-      const url = this.namespaceLink(routingConfig.defaultToNamespace);
-      this.$router.push(url);
-      return;
-    }
-
     await this.getNamespaces();
     if (this.recentNamespaces.length == 1) {
       const namespace = this.recentNamespaces[0];

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -31,7 +31,8 @@ const getRoutingConfig = async () => {
 
   routing.defaultToNamespace =
     routing.default_to_namespace || routing.defaultToNamespace;
-
+  delete routing.default_to_namespace
+  
   return routing;
 };
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -351,18 +351,20 @@ router.get('/api/namespaces/:namespace/task-queues/:taskQueue/', async function(
 });
 
 router.get('/api/web-settings', async (ctx) => {
-  const routingConfig = await getRoutingConfig();
+  const routing = await getRoutingConfig();
+  const { enabled } = await getAuthConfig();
+  const permitWriteApi = isWriteApiPermitted();
+
+  const auth = { enabled }; // only include non-sensitive data
 
   ctx.body = {
-    health: 'OK',
-    routingConfig,
-    permitWriteApi: isWriteApiPermitted(),
+    routing,
+    auth,
+    permitWriteApi,
   };
 });
 
 router.get('/api/me', async (ctx) => {
-  const auth = await getAuthConfig();
-
   let user;
   if (ctx.isAuthenticated() && !!ctx.state.user) {
     const { email, name, picture } = ctx.state.user;
@@ -370,7 +372,6 @@ router.get('/api/me', async (ctx) => {
   }
 
   ctx.body = {
-    isAuthEnabled: auth.enabled,
     user,
   };
 });


### PR DESCRIPTION
- fixes issue of when Web would prioritize `defaultToNamespace` config redirection over signin page (if not signed in)
- moved `auth.enabled` config value from `api/me` to `api/web-settings`