### PR TITLE
Read TLS from main config file, remove separate tls file

### DIFF
--- a/server/tls/read-creds-from-config.js
+++ b/server/tls/read-creds-from-config.js
@@ -1,23 +1,13 @@
-const { readFileSync } = require('fs');
-const yaml = require('js-yaml');
+const { getTlsConfig } = require('../config');
 
-function readCredsFromYml({ configPath }) {
-  if (configPath === undefined) {
-    throw Error('TLS config path is not provided');
-  }
-
-  let credentials;
-
-  const configRaw = readFileSync(configPath);
-  config = yaml.safeLoad(configRaw);
-
+function readCredsFromConfig() {
   const {
     key: keyBase64,
     cert: certBase64,
     ca: caBase64,
-    server_name: serverName,
+    serverName,
     verifyHost,
-  } = config;
+  } = getTlsConfig();
 
   if (!keyBase64) {
     throw Error('TLS key is not provided');
@@ -34,4 +24,4 @@ function readCredsFromYml({ configPath }) {
   return { pk, cert, ca, serverName, verifyHost };
 }
 
-module.exports = { readCredsFromYml };
+module.exports = { readCredsFromConfig };

--- a/server/tls/tls.js
+++ b/server/tls/tls.js
@@ -1,7 +1,8 @@
 const grpc = require('grpc');
 const { readCredsFromCertFiles } = require('./read-creds-from-cert-files');
-const { readCredsFromYml } = require('./read-creds-from-yml-file');
+const { readCredsFromConfig } = require('./read-creds-from-config');
 const { compareCaseInsensitive } = require('../utils');
+const { getTlsConfig } = require('../config');
 
 const keyPath = process.env.TEMPORAL_TLS_KEY_PATH;
 const certPath = process.env.TEMPORAL_TLS_CERT_PATH;
@@ -10,8 +11,7 @@ const serverName = process.env.TEMPORAL_TLS_SERVER_NAME;
 const verifyHost = [true, 'true', undefined].includes(
   process.env.TEMPORAL_TLS_ENABLE_HOST_VERIFICATION
 );
-const configPath = process.env.TEMPORAL_TLS_YML_PATH;
-
+const tlsConfigFile = getTlsConfig()
 function getCredentials() {
   if (keyPath !== undefined) {
     console.log('establishing secure connection using TLS cert files...');
@@ -21,13 +21,11 @@ function getCredentials() {
       caPath,
     });
     return createSecure(pk, cert, ca, serverName, verifyHost);
-  } else if (configPath !== undefined) {
+  } else if (tlsConfigFile.key) {
     console.log(
       'establishing secure connection using TLS yml configuration...'
     );
-    const { pk, cert, ca, serverName, verifyHost } = readCredsFromYml({
-      configPath,
-    });
+    const { pk, cert, ca, serverName, verifyHost } = readCredsFromConfig();
     return createSecure(pk, cert, ca, serverName, verifyHost);
   } else {
     console.log('establishing insecure connection...');


### PR DESCRIPTION
- removes reading `yml based TLS configuration` from TEMPORAL_TLS_YML_PATH
- starts reading it from the main config file (TEMPORAL_CONFIG_PATH)

``` yml
auth: ...
routing: ...
tls:
  cert: <base64>
  key: <base64>
  ca: <base64>
  server_name: my-server
  verify_host: true
```

This change is related to HashiCorp's `Vault` discussions, though doesn't exactly support it (as is). `Vault` requires that all keys are top-level only. Supporting `Vault` is possible by forking how https://github.com/temporalio/web/tree/master/server/config reads the configuration file

**NOTE** The feature is intentionally not documented. We can document this if there is a value for the users and we are good with the format