### PR TITLE
Allow configuring server-side TLS using CA only

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Optional TLS configuration variables:
 | TEMPORAL_TLS_ENABLE_HOST_VERIFICATION | Enables verification of the server certificate                      | true    |
 | TEMPORAL_TLS_SERVER_NAME              | Target server that is used for TLS host verification                |         |
 
-To enable TLS, you need to specify `TEMPORAL_TLS_KEY_PATH` and `TEMPORAL_TLS_CERT_PATH`. 
+* To enable mutual TLS, you need to specify `TEMPORAL_TLS_KEY_PATH` and `TEMPORAL_TLS_CERT_PATH`.
+* For server-side TLS you need to specify only `TEMPORAL_TLS_CA_PATH`.
 
 By default we will also verify your server `hostname`, matching it to `TEMPORAL_TLS_SERVER_NAME`. You can turn this off by setting `TEMPORAL_TLS_ENABLE_HOST_VERIFICATION` to `false`.
 

--- a/server/tls/read-creds-from-cert-files.js
+++ b/server/tls/read-creds-from-cert-files.js
@@ -20,4 +20,12 @@ function readCredsFromCertFiles({ caPath, keyPath, certPath }) {
   return { pk, cert, ca };
 }
 
-module.exports = { readCredsFromCertFiles };
+function readCAFromFile(caPath) {
+  if (!caPath) {
+    throw Error('TLS CA is not provided')
+  }
+
+  return readFileSync(caPath);
+}
+
+module.exports = { readCredsFromCertFiles, readCAFromFile };

--- a/server/tls/read-creds-from-cert-files.js
+++ b/server/tls/read-creds-from-cert-files.js
@@ -1,31 +1,15 @@
 const { readFileSync } = require('fs');
 
 function readCredsFromCertFiles({ caPath, keyPath, certPath }) {
-  if (!keyPath) {
-    throw Error('TLS key is not provided');
+  if (!caPath && (!keyPath || !certPath)) {
+    throw Error('must provide TLS key and cert or only CA')
   }
 
-  if (!certPath) {
-    throw Error('TLS certificate is not provided');
-  }
-
-  const pk = readFileSync(keyPath);
-  const cert = readFileSync(certPath);
-
-  let ca;
-  if (caPath) {
-    ca = readFileSync(caPath);
-  }
+  const pk = keyPath ? readFileSync(keyPath) : undefined;
+  const cert = certPath ? readFileSync(certPath) : undefined;
+  const ca = caPath ? readFileSync(caPath) : undefined;
 
   return { pk, cert, ca };
 }
 
-function readCAFromFile(caPath) {
-  if (!caPath) {
-    throw Error('TLS CA is not provided')
-  }
-
-  return readFileSync(caPath);
-}
-
-module.exports = { readCredsFromCertFiles, readCAFromFile };
+module.exports = { readCredsFromCertFiles };

--- a/server/tls/read-creds-from-cert-files.js
+++ b/server/tls/read-creds-from-cert-files.js
@@ -2,7 +2,7 @@ const { readFileSync } = require('fs');
 
 function readCredsFromCertFiles({ caPath, keyPath, certPath }) {
   if (!caPath && (!keyPath || !certPath)) {
-    throw Error('must provide TLS key and cert or only CA')
+    throw Error('TLS connection error: must provide CA or key and cert paths')
   }
 
   const pk = keyPath ? readFileSync(keyPath) : undefined;

--- a/server/tls/tls.js
+++ b/server/tls/tls.js
@@ -1,5 +1,5 @@
 const grpc = require('grpc');
-const { readCredsFromCertFiles, readCAFromFile } = require('./read-creds-from-cert-files');
+const { readCredsFromCertFiles } = require('./read-creds-from-cert-files');
 const { readCredsFromConfig } = require('./read-creds-from-config');
 const { compareCaseInsensitive } = require('../utils');
 const { getTlsConfig } = require('../config');
@@ -13,7 +13,7 @@ const verifyHost = [true, 'true', undefined].includes(
 );
 const tlsConfigFile = getTlsConfig()
 function getCredentials() {
-  if (keyPath !== undefined) {
+  if (keyPath !== undefined && certPath !== undefined) {
     console.log('establishing secure connection using TLS cert files...');
     const { pk, cert, ca } = readCredsFromCertFiles({
       keyPath,
@@ -21,9 +21,9 @@ function getCredentials() {
       caPath,
     });
     return createSecure(pk, cert, ca, serverName, verifyHost);
-  } else if (caPath !== undefined && certPath === undefined) {
+  } else if (caPath !== undefined) {
     console.log('establishing server-side TLS connection using only TLS CA file...');
-    const ca = readCAFromFile(caPath);
+    const { ca } = readCredsFromCertFiles({ caPath });
     return createSecure(undefined, undefined, ca, serverName, verifyHost);
   } else if (tlsConfigFile.key) {
     console.log(

--- a/server/tls/tls.js
+++ b/server/tls/tls.js
@@ -1,5 +1,5 @@
 const grpc = require('grpc');
-const { readCredsFromCertFiles } = require('./read-creds-from-cert-files');
+const { readCredsFromCertFiles, readCAFromFile } = require('./read-creds-from-cert-files');
 const { readCredsFromConfig } = require('./read-creds-from-config');
 const { compareCaseInsensitive } = require('../utils');
 const { getTlsConfig } = require('../config');
@@ -21,6 +21,10 @@ function getCredentials() {
       caPath,
     });
     return createSecure(pk, cert, ca, serverName, verifyHost);
+  } else if (caPath !== undefined && certPath === undefined) {
+    console.log('establishing server-side TLS connection using only TLS CA file...');
+    const ca = readCAFromFile(caPath);
+    return createSecure(undefined, undefined, ca, serverName, verifyHost);
   } else if (tlsConfigFile.key) {
     console.log(
       'establishing secure connection using TLS yml configuration...'


### PR DESCRIPTION
As stated in the [configuration instructions](https://github.com/temporalio/web#configuration) in the README, TLS requires both CERT and KEY path to be defined, for mTLS.

Correct me if I'm wrong, but it is currently not possible to configure server-side TLS, by specifying the CA path only.

In our setup, temporal-server is running as an ECS task, with an associated target group (configured as gRPC). An AWS ELB routes requests to this target group and does TLS termination. Our temporal-web must reach temporal-server through the ELB, therefore we must configure it for server-side TLS.

The changes suggested in this PR allow creating credentials using CA only for server-side TLS, and add a note regarding that to the README.

Let me know how I can improve it, happy to contribute.

PS: *I realize I must sign the Temporal Contributor License Agreement before acceptance, is a signed PDF alright? Let me know where I should send it.*