### PR TITLE
Support passing auth id token to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enabl
             scope: openid profile email
             audience: temporal # identifier of the audience for an issued token (optional)
             callback_base_uri: http://localhost:8088
+            pass_id_token: false # adds ID token as 'authorization-extras' header with every request to server
     ```
 
     <details>

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -23,16 +23,18 @@ const initialize = async (ctx, next) => {
       client_secret: clientSecret,
       scope,
       audience,
-      callback_base_uri: callbackUri,
+      callback_base_uri: callbackUriBase,
+      pass_id_token: passIdToken,
     } = auth.providers[0]; // we currently support single auth config
-    const strategy = await oidc.getStrategy(
+    const strategy = await oidc.getStrategy({
       issuer,
       clientId,
       clientSecret,
-      scope || 'openid profile email',
+      scope: scope || 'openid profile email',
       audience,
-      callbackUri
-    );
+      callbackUriBase,
+      passIdToken,
+    });
     passport.use(STRATEGY_NAMES.oidc, strategy);
 
     passport.serializeUser((user, done) => {

--- a/server/auth/oidc.js
+++ b/server/auth/oidc.js
@@ -12,24 +12,32 @@ async function getClient(issuerUrl, clientId, clientSecret, callbackUriBase) {
   });
 }
 
-const verify = (tokenSet, userinfo, done) => {
-  const { access_token: accessToken } = tokenSet;
-  const { email, name, picture } = userinfo;
+const verify = ({ passIdToken }) => {
+  return (tokenSet, userinfo, done) => {
+    const { access_token: accessToken, id_token: idToken } = tokenSet;
+    const { email, name, picture } = userinfo;
 
-  const user = { email, name, picture, accessToken };
-  return done(null, user);
+    const user = { email, name, picture, accessToken };
+
+    if (passIdToken) {
+      user.idToken = idToken;
+    }
+
+    return done(null, user);
+  };
 };
 
-const getStrategy = async (
-  issuerUrl,
+const getStrategy = async ({
+  issuer,
   clientId,
   clientSecret,
   scope,
   audience,
-  callbackUriBase
-) => {
+  callbackUriBase,
+  passIdToken,
+}) => {
   const client = await getClient(
-    issuerUrl,
+    issuer,
     clientId,
     clientSecret,
     callbackUriBase
@@ -40,7 +48,7 @@ const getStrategy = async (
     response: ['userinfo'],
   };
 
-  return new Strategy({ client, params }, verify);
+  return new Strategy({ client, params }, verify({ passIdToken }));
 };
 
 module.exports = { getStrategy };

--- a/server/config.yml
+++ b/server/config.yml
@@ -9,7 +9,7 @@ auth:
       #   client_secret: xxxxxxxxxxxxxxxxxxxxxxx
       #   scope: openid profile email
       #   callback_base_uri: http://localhost:8088
-
+      #   pass_id_token: false
 # for more info see docs: https://github.com/temporalio/web#configuring-authentication-optional
 
 routing:

--- a/server/temporal-client/with-auth-metadata.js
+++ b/server/temporal-client/with-auth-metadata.js
@@ -25,11 +25,12 @@ const getter = (obj, property) => {
   return obj[property];
 };
 
-const extractAccessToken = (ctx) => {
+const extractTokens = (ctx) => {
   if (ctx.isAuthenticated()) {
-    return ctx.state.user.accessToken;
+    const { accessToken, idToken } = ctx.state.user;
+    return { accessToken, idToken };
   }
-  return undefined;
+  return { accessToken: undefined, idToken: undefined };
 };
 
 const buildGrpcMetadata = async (ctx) => {
@@ -37,11 +38,14 @@ const buildGrpcMetadata = async (ctx) => {
 
   const auth = await getAuthConfig();
   if (auth.enabled) {
-    const accessToken = extractAccessToken(ctx);
+    const { accessToken, idToken } = extractTokens(ctx);
     if (!accessToken) {
-      throw Error('Request unauthorized')
+      throw Error('Request unauthorized');
     }
     metadata.add('authorization', `Bearer ${accessToken}`);
+    if (idToken) {
+      metadata.add('authorization-extras', idToken);
+    }
   }
   return metadata;
 };


### PR DESCRIPTION
Adds support to pass ID token to server. The token is set as part of `authorization-extras` header

To enable, set `pass_id_token` to `true` in the provider configs

related PR -https://github.com/temporalio/temporal/pull/1113