### PR TITLE
Fix workflows ALL view showing empty space

### DIFF
--- a/client/routes/namespace/workflow-list.vue
+++ b/client/routes/namespace/workflow-list.vue
@@ -314,41 +314,47 @@ export default {
         );
         this.nptAlt = nptClosed;
 
-        // saturate diff in workflows between the max dates
-        // so both open and closed workflows are fetched until the same date
-        let maxOpen = maxBy(wfsOpen, (w) => moment(w.startTime));
-        let maxClosed = maxBy(wfsClosed, (w) => moment(w.startTime));
-
-        let nptDiff;
         let wfsDiff = [];
-        let saturateOpen;
+        if (this.npt && this.nptAlt) {
+          // saturate diff in workflows between the max dates
+          // so both open and closed workflows are fetched until the same date
+          let maxOpen = maxBy(wfsOpen, (w) => moment(w.startTime));
+          let maxClosed = maxBy(wfsClosed, (w) => moment(w.startTime));
 
-        if (maxOpen && maxClosed && maxOpen.startTime !== maxClosed.startTime) {
-          maxOpen = moment(maxOpen.startTime);
-          maxClosed = moment(maxClosed.startTime);
-          saturateOpen = maxOpen < maxClosed;
+          let nptDiff;
+          let saturateOpen;
 
-          let [startTime, endTime] = saturateOpen
-            ? [maxOpen, maxClosed]
-            : [maxClosed, maxOpen];
-          startTime = startTime.add(1, 'milliseconds').toISOString();
-          endTime = endTime.add(1, 'milliseconds').toISOString();
-          const queryDiff = { ...this.criteria, startTime, endTime };
+          if (
+            maxOpen &&
+            maxClosed &&
+            maxOpen.startTime !== maxClosed.startTime
+          ) {
+            maxOpen = moment(maxOpen.startTime);
+            maxClosed = moment(maxClosed.startTime);
+            saturateOpen = maxOpen < maxClosed;
 
-          let diff = await this.fetch(
-            `/api/namespaces/${namespace}/workflows/${
-              saturateOpen ? 'open' : 'closed'
-            }`,
-            queryDiff
-          );
+            let [startTime, endTime] = saturateOpen
+              ? [maxOpen, maxClosed]
+              : [maxClosed, maxOpen];
+            startTime = startTime.add(1, 'seconds').toISOString();
+            endTime = endTime.add(1, 'seconds').toISOString();
+            const queryDiff = { ...this.criteria, startTime, endTime };
 
-          wfsDiff = diff.workflows;
-          nptDiff = diff.nextPageToken;
+            let diff = await this.fetch(
+              `/api/namespaces/${namespace}/workflows/${
+                saturateOpen ? 'open' : 'closed'
+              }`,
+              queryDiff
+            );
 
-          if (saturateOpen === true) {
-            this.npt = nptDiff;
-          } else if (saturateOpen === false) {
-            this.nptAlt = nptDiff;
+            wfsDiff = diff.workflows;
+            nptDiff = diff.nextPageToken;
+
+            if (saturateOpen === true) {
+              this.npt = nptDiff;
+            } else if (saturateOpen === false) {
+              this.nptAlt = nptDiff;
+            }
           }
         }
 


### PR DESCRIPTION
#### Bug description:

There is a bug at step 3 below, when the ALL view makes 3 requests to fetch a Open&Closed workflows for a page: 
 - 1. fetch Open wfs 
 - 2. fetch Closed wfs 
 - 3. compare the results by start date and fetch missing wfs, so the next round of requests would start from the same startDate

If one of the (1) Open or (2) Closed Workflows fetch requests would return an empty `nextPageToken` (meaning no more workflows to fetch), ALL view could still try to fetch (3) even with empty page token. With empty `nextPageToken`, the result returns the same data as from the previous requests (either 1 or 2).

This leads to data duplication, that on UI is shown as empty space
![image](https://user-images.githubusercontent.com/11838981/103872815-c1f61580-5083-11eb-9a5c-7843c860dfa5.png)
