### PR TITLE
Fix date range filter dropping out running workflows

### DIFF
--- a/client/routes/namespace/workflow-list.vue
+++ b/client/routes/namespace/workflow-list.vue
@@ -232,7 +232,7 @@ export default {
         status: { value: status },
       } = this;
 
-      if (status === 'OPEN') {
+      if (['OPEN', 'ALL'].includes(status)) {
         return null;
       }
 


### PR DESCRIPTION
In workflows `all` view, the date range filter was allowing to choose the ranges only starting from the `retention period` days ago. thus disallowing to see running workflows that could be older than the retention period.
with the fix, the range goes up to 3 months ago
![image](https://user-images.githubusercontent.com/11838981/103966824-8146dc80-5115-11eb-9d47-05fd50d7143c.png)
