### PR TITLE
Fix security headers not being set for root url

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -57,17 +57,6 @@ app.init = function(options) {
         filter: (contentType) => !contentType.startsWith('text/event-stream'),
       })
     )
-    .use(
-      useWebpack
-        ? koaWebpack({
-            compiler,
-            dev: { stats: { colors: true } },
-            hot: {
-              port: process.env.TEST_RUN ? hotReloadTestPort : hotReloadPort,
-            },
-          })
-        : require('koa-static')(staticRoot)
-    )
     .use(session({}, app))
     .use(auth.initialize)
     .use(passport.initialize())
@@ -80,6 +69,17 @@ app.init = function(options) {
     .use(router.prefix(PUBLIC_PATH).routes())
     .use(router.allowedMethods())
     .use(securityHeaders({ ignorePaths: ['/api'] }))
+    .use(
+      useWebpack
+        ? koaWebpack({
+            compiler,
+            dev: { stats: { colors: true } },
+            hot: {
+              port: process.env.TEST_RUN ? hotReloadTestPort : hotReloadPort,
+            },
+          })
+        : require('koa-static')(staticRoot)
+    )
     .use(async function(ctx, next) {
       if (
         ['HEAD', 'GET'].includes(ctx.method) &&


### PR DESCRIPTION
This ideally should be fixed by `historyApiFallback` webpack setting instead. However seems it doesn't work with this version of webpack. The original developers have actually set this setting in webpack config and then worked around with the custom middleware serving `index.html` for non-root urls (ex `/namespace`)

Changed the order of middlewares making security tokens to be set before the first middleware that serves static files (`index.html`)