### PR TITLE
Fixes CSRF Header Handling

### DIFF
--- a/client/helpers/http.js
+++ b/client/helpers/http.js
@@ -1,4 +1,6 @@
 const PUBLIC_PATH = process.env.TEMPORAL_WEB_ROOT_PATH || '/';
+const CSRF_HEADER_NAME = "x-csrf-token"
+
 export default function http(fetch, url, o) {
   const opts = {
     credentials: 'same-origin',
@@ -49,9 +51,9 @@ const addCsrf = (opts) => {
   const cookieName = 'csrf-token';
   const cookies = document.cookie.split(';');
   let csrf = cookies.find((c) => c.includes(cookieName));
-  if (csrf && !opts.headers['X-CSRF-TOKEN']) {
+  if (csrf && !opts.headers[CSRF_HEADER_NAME]) {
     csrf = csrf.slice(cookieName.length + 1);
-    opts.headers['X-CSRF-TOKEN'] = csrf;
+    opts.headers[CSRF_HEADER_NAME] = csrf;
   }
   return opts;
 };

--- a/client/helpers/http.js
+++ b/client/helpers/http.js
@@ -52,7 +52,7 @@ const addCsrf = (opts) => {
   const cookies = document.cookie.split(';');
   let csrf = cookies.find((c) => c.includes(cookieName));
   if (csrf && !opts.headers[CSRF_HEADER_NAME]) {
-    csrf = csrf.slice(cookieName.length + 1);
+    csrf = csrf.slice(cookieName.length + 2);
     opts.headers[CSRF_HEADER_NAME] = csrf;
   }
   return opts;

--- a/client/helpers/http.js
+++ b/client/helpers/http.js
@@ -1,5 +1,4 @@
 const PUBLIC_PATH = process.env.TEMPORAL_WEB_ROOT_PATH || '/';
-const CSRF_HEADER_NAME = "x-csrf-token"
 
 export default function http(fetch, url, o) {
   const opts = {
@@ -49,11 +48,12 @@ http.post = function post(fetch, url, body) {
 
 const addCsrf = (opts) => {
   const cookieName = 'csrf-token';
+  const headerName = 'X-CSRF-TOKEN';
   const cookies = document.cookie.split(';');
   let csrf = cookies.find((c) => c.includes(cookieName));
-  if (csrf && !opts.headers[CSRF_HEADER_NAME]) {
+  if (csrf && !opts.headers[headerName]) {
     csrf = csrf.slice(cookieName.length + 2);
-    opts.headers[CSRF_HEADER_NAME] = csrf;
+    opts.headers[headerName] = csrf;
   }
   return opts;
 };


### PR DESCRIPTION
Version 1.6.2 of the Temporal Web Client saw an "Invalid CSRF Token" error being thrown for any POST request.

This was due to the cookie parser encountering an off-by-one error, meaning that all CSRF tokens were prefixed with `=`.

This PR adds a constant for the CSRF header name, and ensures that the correct value is parsed from the cookie.