### PR TITLE
Fix invalid CSRF token when there are multiple cookies

### DIFF
--- a/client/helpers/http.js
+++ b/client/helpers/http.js
@@ -50,7 +50,7 @@ const addCsrf = (opts) => {
   const cookies = document.cookie.split(';');
   let csrf = cookies.find((c) => c.includes(cookieName));
   if (csrf && !opts.headers['X-CSRF-TOKEN']) {
-    csrf = csrf.slice(cookieName.length + 1);
+    csrf = csrf.trim().slice(cookieName.length + 1);
     opts.headers['X-CSRF-TOKEN'] = csrf;
   }
   return opts;


### PR DESCRIPTION
The logic for pulling the CSRF token out from the cookies did
not account for multiple cookies, and whitespace between them, e.g.

	cookieA=value1; cookieB=value2

Consequently, when the CSRF token was pulled from the cookies,
the slice would not have accounted for the extra space,
e.g. `<whitespace>csrf-token=abcdef` => `=abcdef` as the final CSRF token.

Potentially resolves one cause of #258