### PR TITLE
Fix csrf corner cases and add tests

### DIFF
--- a/client/helpers/http.js
+++ b/client/helpers/http.js
@@ -45,13 +45,14 @@ http.post = function post(fetch, url, body) {
   return http(fetch, url, opts);
 };
 
-const addCsrf = (opts) => {
-  const cookieName = 'csrf-token';
+export const addCsrf = (opts) => {
+  const csrfCookie = 'csrf-token=';
+  const csrfHeader = 'X-CSRF-TOKEN';
   const cookies = document.cookie.split(';');
-  let csrf = cookies.find((c) => c.includes(cookieName));
-  if (csrf && !opts.headers['X-CSRF-TOKEN']) {
-    csrf = csrf.trim().slice(cookieName.length + 1);
-    opts.headers['X-CSRF-TOKEN'] = csrf;
+  let csrf = cookies.find((c) => c.includes(csrfCookie));
+  if (csrf && !opts.headers[csrfHeader]) {
+    csrf = csrf.trim().slice(csrfCookie.length);
+    opts.headers[csrfHeader] = csrf;
   }
   return opts;
 };

--- a/client/helpers/https.spec.js
+++ b/client/helpers/https.spec.js
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { addCsrf } from './http';
+
+describe('cross site request forgery (CSRF)', () => {
+  let opts;
+
+  beforeEach(() => {
+    opts = {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+  });
+
+  describe('When no csrf cookie is set', () => {
+    it('should not set CSRF header', () => {
+      document.cookie =
+        'sample-token=xxxxx; sample-token.sig=yyyyy';
+      opts = addCsrf(opts);
+
+      expect(opts.headers['X-CSRF-TOKEN']).toEqual(undefined);
+    });
+  });
+
+  describe('When single cookie is present and is csrf', () => {
+    it('should set CSRF header', () => {
+      document.cookie =
+        'csrf-token=xxxxx; sample-token.sig=yyyyy';
+      opts = addCsrf(opts);
+
+      expect(opts.headers['X-CSRF-TOKEN']).toEqual('xxxxx');
+    });
+  });
+
+  describe('When csrf cookie is present and is not first', () => {
+    it('should set CSRF header', () => {
+      document.cookie =
+        'sample-token=zzzzzz; csrf-token=xxxxx; sample-token.sig=yyyyy';
+      opts = addCsrf(opts);
+
+      expect(opts.headers['X-CSRF-TOKEN']).toEqual('xxxxx');
+    });
+  });
+
+  describe('When csrf cookie is pre-fixed with a space', () => {
+    it('should trim spaces and set CSRF header', () => {
+      document.cookie =
+        ' csrf-token=xxxxx ;';
+      opts = addCsrf(opts);
+
+      expect(opts.headers['X-CSRF-TOKEN']).toEqual('xxxxx');
+    });
+  });
+  
+  describe('When csrf cookie is pre-fixed with a space', () => {
+    it('should trim spaces and set CSRF header', () => {
+      document.cookie =
+        ' csrf-token=xxxxx ;';
+      opts = addCsrf(opts);
+
+      expect(opts.headers['X-CSRF-TOKEN']).toEqual('xxxxx');
+    });
+  });
+
+  describe('When csrf cookie has spaces', () => {
+    it('should trim spaces and set CSRF header', () => {
+      document.cookie =
+        ' csrf-token=xxxxx ;';
+      opts = addCsrf(opts);
+
+      expect(opts.headers['X-CSRF-TOKEN']).toEqual('xxxxx');
+    });
+  });
+
+  describe('When csrf cookie is preceded by csrf signature', () => {
+    it('should trim spaces and set CSRF header', () => {
+      document.cookie =
+        'sample-token.sig=yyyyy; csrf-token=xxxxx;';
+      opts = addCsrf(opts);
+
+      expect(opts.headers['X-CSRF-TOKEN']).toEqual('xxxxx');
+    });
+  });
+});


### PR DESCRIPTION
- fixes another corner case when CSRF token is present **after**  `csrf-token.sig` (signature) 
- adds unit tests

fix #258