### PR TITLE
Customize version announcement message and severity

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -57,6 +57,7 @@ export default {
         message: '',
         show: false,
         link: '',
+        severity: ''
       },
       onVersionAnnouncementClose: () => {},
       webSettings: undefined,
@@ -129,11 +130,11 @@ export default {
       }
     },
     async announceNewVersionIfExists() {
-      const { show, message, link, version } = await getNewVersionAnnouncement(
+      const { show, message, link, version, severity } = await getNewVersionAnnouncement(
         this.$http,
         this.onNotification
       );
-      this.announcement = { show, message, link };
+      this.announcement = { show, message, link, severity };
       if (version) {
         this.onVersionAnnouncementClose = () =>
           discardVersionAnnouncement(version);
@@ -173,6 +174,7 @@ export default {
       :onClose="onAnnouncementClose"
       :show="announcement.show"
       :link="announcement.link"
+      :severity="announcement.severity"
     />
     <header class="top-bar">
       <router-link :to="{ name: 'namespaces' }" class="logo">

--- a/client/components/announcement-bar.vue
+++ b/client/components/announcement-bar.vue
@@ -1,5 +1,10 @@
 <template>
-  <div data-color="announce" class="announcement-bar" v-if="show">
+  <div
+    data-color="announce"
+    class="announcement-bar"
+    :class="severity"
+    v-if="show"
+  >
     <a :href="link" target="_blank">
       <span class="message">
         {{ message }}
@@ -12,7 +17,7 @@
 <script>
 export default {
   name: 'notification-bar',
-  props: ['message', 'link', 'show', 'onClose'],
+  props: ['message', 'link', 'show', 'severity', 'onClose'],
 };
 </script>
 
@@ -28,6 +33,10 @@ export default {
   padding: 0.25rem 0;
   text-align: center;
   color: temporal-spaceblack;
+
+  &.high {
+    background-color: uber-yellow
+  }
 
   a {
     color: inherit;

--- a/client/features/version-info/version-info.js
+++ b/client/features/version-info/version-info.js
@@ -29,12 +29,25 @@ export const getNewVersionAnnouncement = async (http, showNotification) => {
       return { show: false };
     }
 
-    const message = `🪐 ${versionR} version is available!`;
+    const { instructions, alerts } = versionInfo;
+    let alertMessage = '';
+    let severity = '';
+    if (alerts && alerts.length > 0) {
+      alertMessage = alerts[0].message;
+      severity = (alerts[0].severity || '').toLowerCase();
+    }
+
+    let message = `🪐 ${versionR} version is available!`;
+    if (alertMessage || instructions) {
+      message = alertMessage ? `${alertMessage} ` : '' + instructions;
+    }
+
     return {
       show: true,
       message,
       version: versionR,
       link: `${_githubReleases}${versionR}`,
+      severity,
     };
   } catch (err) {
     const message = getErrorMessage(err);

--- a/server/temporal-client/helpers.js
+++ b/server/temporal-client/helpers.js
@@ -169,6 +169,7 @@ function enumTransform(item) {
     'timeout_type',
     'archival_state',
     'retry_state',
+    'severity',
   ];
 
   const itemL = item.toLowerCase();


### PR DESCRIPTION
- New version message now shows the version info service message
- Background color is driven by `severity`

High severity color:
![image](https://user-images.githubusercontent.com/11838981/109373611-bc87a100-7864-11eb-9103-7008cc2bbb2c.png)
