### PR TITLE
Support custom issue report links

### DIFF
--- a/client/routes/namespace/index.vue
+++ b/client/routes/namespace/index.vue
@@ -18,10 +18,7 @@
         :to="{ name: 'workflow-archival' }"
       />
       <span class="bugreport">
-        <a
-          target="_blank"
-          href="https://github.com/temporalio/web/issues/new/choose"
-        >
+        <a target="_blank" :href="issueReportLink">
           Report Bug/Give Feedback
         </a>
       </span>
@@ -40,6 +37,32 @@ export default {
   components: {
     'navigation-bar': NavigationBar,
     'navigation-link': NavigationLink,
+  },
+  data() {
+    return {
+      webSettings: undefined,
+    };
+  },
+  async created() {
+    await this.getWebSettings();
+  },
+  computed: {
+    issueReportLink() {
+      if (!this.webSettings?.routing?.issueReportLink) {
+        return 'https://github.com/temporalio/web/issues/new/choose';
+      }
+
+      return this.webSettings.routing.issueReportLink;
+    },
+  },
+  methods: {
+    async getWebSettings() {
+      if (this.webSettings) {
+        return this.webSettings;
+      }
+
+      this.webSettings = await this.$http(`/api/web-settings`);
+    },
   },
 };
 </script>

--- a/server/config.yml
+++ b/server/config.yml
@@ -13,5 +13,5 @@ auth:
 # for more info see docs: https://github.com/temporalio/web#configuring-authentication-optional
 
 routing:
-  default_to_namespace: # my_namespace
-  issue_report_link: https://github.com/temporalio/web/issues/new/choose
+  default_to_namespace: # set this field if your default namespace isn't named 'default'
+  issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums

--- a/server/config.yml
+++ b/server/config.yml
@@ -14,3 +14,4 @@ auth:
 
 routing:
   default_to_namespace: # my_namespace
+  issue_report_link: https://github.com/temporalio/web/issues/new/choose

--- a/server/config.yml
+++ b/server/config.yml
@@ -13,5 +13,5 @@ auth:
 # for more info see docs: https://github.com/temporalio/web#configuring-authentication-optional
 
 routing:
-  default_to_namespace: # set this field if your default namespace isn't named 'default'
+  default_to_namespace: # internal use only
   issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -34,16 +34,22 @@ const getAuthConfig = async () => {
 };
 
 const getRoutingConfig = async () => {
-  let { routing } = await readConfig();
+  const { routing } = await readConfig();
+
   if (!routing) {
-    return { defaultToNamespace: null };
+    return { defaultToNamespace: null, issueReportLink: null };
   }
 
-  routing.defaultToNamespace =
+  // backwards compatibility fix
+  routing.default_to_namespace =
     routing.default_to_namespace || routing.defaultToNamespace;
-  delete routing.default_to_namespace;
 
-  return routing;
+  const { default_to_namespace, issue_report_link } = routing;
+
+  return {
+    defaultToNamespace: default_to_namespace,
+    issueReportLink: issue_report_link,
+  };
 };
 
 const getTlsConfig = () => {


### PR DESCRIPTION
per user request:
Allows to customize the issue report link through config.yml file

``` yaml
routing:
  default_to_namespace: # my_namespace
  issue_report_link: https://github.com/temporalio/web/issues/new/choose
```

![image](https://user-images.githubusercontent.com/11838981/110721343-37d24680-81c5-11eb-9f92-56bf89fa18c1.png)