### PR TITLE
Ensure propagating-hammerjs is not upgraded

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "extract-text-webpack-plugin": "^3.0.1",
     "file-loader": "^1.1.5",
     "friendly-querystring": "^0.2.0",
+    "hammerjs": "2.0.8",
+    "propagating-hammerjs": "1.4.7",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^2.30.1",
     "html-webpack-template": "^6.1.0",


### PR DESCRIPTION
<!--- Reminder to change the title 👆 -->

<!--- For External Contributors -->
<!-- Thanks for opening a PR to our repos! If it is a significant code change,
please make sure there is an  opened issue where we have accepted the idea
before filing this PR. -->

<!--- For All Contributors -->

## What was changed:
<!-- Describe what has changed in this PR -->
Completely lock propagating-hammerjs version

## Why?
<!-- Tell your future self why have you made these changes -->
Newer version is broken. There is unlikely ever a need in `web` for this package to be upgraded. It is eventually used by custom also locked version of `vis` package that is used to draw a graph of history events

## Closes issue: 
<!--- If it fixes an open issue, please link to the issue here -->

## How has this been tested?
<!--- Please describe how you tested your changes/how we can test them -->
Running locally + to be tested in CICD

## Any docs updates needed?
<!--- update docs/README in this repo if applicable, or point out where to update docs.temporal.io -->
