### PR TITLE
Support decrypting of history payloads

### DIFF
--- a/client/features/data-encryption.js
+++ b/client/features/data-encryption.js
@@ -1,14 +1,5 @@
 import WebSocketAsPromised from 'websocket-as-promised';
 
-const payloadAsBase64 = payload => {
-  payload.data = Buffer.from(JSON.stringify(payload.data)).toString('base64');
-  payload.metadata.encoding = Buffer.from(payload.metadata.encoding).toString(
-    'base64'
-  );
-
-  return payload;
-};
-
 export const decryptEventPayloads = async (events, port) => {
   const sock = new WebSocketAsPromised(`ws://localhost:${port}/`, {
     packMessage: data => JSON.stringify(data),
@@ -32,10 +23,6 @@ export const decryptEventPayloads = async (events, port) => {
       }
 
       payloads.forEach((payload, i) => {
-        if (payload.metadata.encoding === 'json/plain') {
-          payload = payloadAsBase64(payload);
-        }
-
         requests.push(
           sock
             .sendRequest({ payload: JSON.stringify(payload) })

--- a/client/features/data-encryption.js
+++ b/client/features/data-encryption.js
@@ -18,9 +18,7 @@ export const decryptEventPayloads = async (events, port) => {
 
       if (event.details.input) {
         payloads = event.details.input.payloads;
-      }
-
-      if (event.details.result) {
+      } else if (event.details.result) {
         payloads = event.details.result.payloads;
       }
 

--- a/client/features/data-encryption.js
+++ b/client/features/data-encryption.js
@@ -33,10 +33,10 @@ export const decryptEventPayloads = async (events, port) => {
       });
     });
     await Promise.all(requests);
-  } catch (error) {
-    console.log(error);
+  } catch (err) {
+    const message = `Unable to decrypt event payload: ${err}`;
 
-    return Promise.reject(error);
+    return Promise.reject({ message });
   } finally {
     if (sock.isOpened) {
       await sock.close();

--- a/client/features/data-encryption.js
+++ b/client/features/data-encryption.js
@@ -1,5 +1,14 @@
 import WebSocketAsPromised from 'websocket-as-promised';
 
+const payloadAsBase64 = payload => {
+  payload.data = Buffer.from(JSON.stringify(payload.data)).toString('base64');
+  payload.metadata.encoding = Buffer.from(payload.metadata.encoding).toString(
+    'base64'
+  );
+
+  return payload;
+};
+
 export const decryptEventPayloads = async (events, port) => {
   const sock = new WebSocketAsPromised(`ws://localhost:${port}/`, {
     packMessage: data => JSON.stringify(data),
@@ -23,6 +32,10 @@ export const decryptEventPayloads = async (events, port) => {
       }
 
       payloads.forEach((payload, i) => {
+        if (payload.metadata.encoding === 'json/plain') {
+          payload = payloadAsBase64(payload);
+        }
+
         requests.push(
           sock
             .sendRequest({ payload: JSON.stringify(payload) })

--- a/client/features/data-encryption.js
+++ b/client/features/data-encryption.js
@@ -1,0 +1,49 @@
+import WebSocketAsPromised from 'websocket-as-promised';
+
+export const decryptEventPayloads = async (events, port) => {
+  const sock = new WebSocketAsPromised(`ws://localhost:${port}/`, {
+    packMessage: data => JSON.stringify(data),
+    unpackMessage: data => JSON.parse(data),
+    attachRequestId: (data, requestId) =>
+      Object.assign({ requestId: requestId }, data),
+    extractRequestId: data => data && data.requestId,
+  });
+
+  try {
+    await sock.open();
+    const requests = [];
+
+    events.forEach(event => {
+      let payloads = [];
+
+      if (event.details.input) {
+        payloads = event.details.input.payloads;
+      }
+
+      if (event.details.result) {
+        payloads = event.details.result.payloads;
+      }
+
+      payloads.forEach((payload, i) => {
+        requests.push(
+          sock
+            .sendRequest({ payload: JSON.stringify(payload) })
+            .then(response => {
+              payloads[i] = JSON.parse(response.content);
+            })
+        );
+      });
+    });
+    await Promise.all(requests);
+  } catch (error) {
+    console.log(error);
+
+    return Promise.reject(error);
+  } finally {
+    if (sock.isOpened) {
+      await sock.close();
+    }
+  }
+
+  return events;
+};

--- a/client/main.js
+++ b/client/main.js
@@ -172,6 +172,16 @@ const routeOpts = {
     // redirects
 
     {
+      name: 'data-converter',
+      path: '/data-converter/:port',
+      beforeEnter: async (to, _from, next) => {
+        await http.global.post(
+          `/api/web-settings/data-converter/${to.params.port}`
+        );
+        next('/');
+      },
+    },
+    {
       name: 'namespaces-redirect',
       path: '/namespace/*',
       redirect: '/namespaces/*',

--- a/client/routes/workflow/helpers/get-query-result.js
+++ b/client/routes/workflow/helpers/get-query-result.js
@@ -1,5 +1,9 @@
 const getQueryResult = queryResponse => {
-  return { payloads: JSON.parse(queryResponse.payloads) };
+  if (typeof queryResponse?.payloads === 'string') {
+    return { payloads: JSON.parse(queryResponse.payloads) };
+  }
+
+  return queryResponse;
 };
 
 export { getQueryResult };

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -114,10 +114,10 @@ export default {
   },
   props: ['namespace', 'runId', 'workflowId'],
   async created() {
+    await this.getWebSettings();
     this.unwatch.push(
       this.$watch('baseAPIURL', this.onBaseApiUrlChange, { immediate: true })
     );
-    await this.getWebSettings();
   },
   beforeDestroy() {
     this.clearWatches();

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -206,7 +206,16 @@ export default {
             return events;
           }
 
-          return decryptEventPayloads(events, port);
+          return decryptEventPayloads(events, port).catch(error => {
+            console.error(error);
+
+            this.$emit('onNotification', {
+              message: getErrorMessage(error),
+              type: NOTIFICATION_TYPE_ERROR,
+            });
+
+            return events;
+          });
         })
         .then(events => {
           const shouldHighlightEventId =

--- a/package-lock.json
+++ b/package-lock.json
@@ -3279,6 +3279,11 @@
       "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
       "dev": true
     },
+    "chnl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/chnl/-/chnl-1.2.0.tgz",
+      "integrity": "sha512-g5gJb59edwCliFbX2j7G6sBfY4sX9YLy211yctONI2GRaiX0f2zIbKWmBm+sPqFNEpM7Ljzm7IJX/xrjiEbPrw=="
+    },
     "chokidar": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
@@ -10651,6 +10656,11 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-controller": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-controller/-/promise-controller-1.0.0.tgz",
+      "integrity": "sha512-goA0zA9L91tuQbUmiMinSYqlyUtEgg4fxJcjYnLYOQnrktb4o4UqciXDNXiRUPiDBPACmsr1k8jDW4r7UDq9Qw=="
+    },
     "promise-polyfill": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
@@ -10666,6 +10676,11 @@
         "es-abstract": "^1.17.0-next.0",
         "function-bind": "^1.1.1"
       }
+    },
+    "promised-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promised-map/-/promised-map-1.0.0.tgz",
+      "integrity": "sha512-fP9VSMgcml+U2uJ9PBc4/LDQ3ZkJCH4blLNCS6gbH7RHyRZCYs91zxWHqiUy+heFiEMiB2op/qllYoFqmIqdWA=="
     },
     "prompts": {
       "version": "2.3.2",
@@ -13466,6 +13481,17 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
+      }
+    },
+    "websocket-as-promised": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/websocket-as-promised/-/websocket-as-promised-2.0.1.tgz",
+      "integrity": "sha512-ePV26D/D37ughXU9j+DjGmwUbelWJrC/vi+6GK++fRlBJmS7aU9T8ABu47KFF0O7r6XN2NAuqJRpegbUwXZxQg==",
+      "requires": {
+        "chnl": "^1.2.0",
+        "promise-controller": "^1.0.0",
+        "promise.prototype.finally": "^3.1.2",
+        "promised-map": "^1.0.0"
       }
     },
     "whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "vue-template-compiler": "^2.5.2",
     "vue-virtual-scroller": "^1.0.10",
     "vue2-datepicker": "^3.4.1",
-    "webpack": "^3.12.0"
+    "webpack": "^3.12.0",
+    "websocket-as-promised": "^2.0.1"
   },
   "devDependencies": {
     "atob": "^2.1.2",

--- a/server/routes.js
+++ b/server/routes.js
@@ -89,6 +89,7 @@ router.get(
         ? Buffer.from(q.nextPageToken, 'base64')
         : undefined,
       waitForNewEvent: 'waitForNewEvent' in q ? true : undefined,
+      rawPayloads: 'rawPayloads' in q ? true : undefined,
     });
   }
 );
@@ -350,10 +351,16 @@ router.get('/api/namespaces/:namespace/task-queues/:taskQueue/', async function(
   ctx.body = tq;
 });
 
+router.post('/api/web-settings/data-converter/:port', async(ctx) => {
+  ctx.session.dataConverter = { port: ctx.params.port };
+  ctx.status = 200;
+});
+
 router.get('/api/web-settings', async (ctx) => {
   const routing = await getRoutingConfig();
   const { enabled } = await getAuthConfig();
   const permitWriteApi = isWriteApiPermitted();
+  const dataConverter = ctx.session.dataConverter;
 
   const auth = { enabled }; // only include non-sensitive data
 
@@ -361,6 +368,7 @@ router.get('/api/web-settings', async (ctx) => {
     routing,
     auth,
     permitWriteApi,
+    dataConverter,
   };
 });
 

--- a/server/temporal-client/helpers.js
+++ b/server/temporal-client/helpers.js
@@ -56,7 +56,7 @@ const _uiTransformPayloadKeys = [
   _payloads,
 ];
 
-function uiTransform(item) {
+function uiTransform(item, rawPayloads=false) {
   if (!item || typeof item !== 'object') {
     return item;
   }
@@ -96,7 +96,7 @@ function uiTransform(item) {
         item[subkey] = stringval;
       }
     } else if (Array.isArray(subvalue)) {
-      if (subkey === _payloads) {
+      if (subkey === _payloads && !rawPayloads) {
         let payloads = [];
 
         Object.entries(subvalue).forEach(([subkey, payload]) => {
@@ -120,7 +120,7 @@ function uiTransform(item) {
         });
         item[_payloads] = payloads;
       } else {
-        subvalue.forEach(uiTransform);
+        subvalue.forEach(function(item) { uiTransform(item, rawPayloads) });
       }
     } else if (typeof subvalue == 'string') {
       subvalue = enumTransform(subvalue);
@@ -144,10 +144,10 @@ function uiTransform(item) {
           });
           item[subkey] = values;
         } else {
-          uiTransform(subvalue);
+          uiTransform(subvalue, rawPayloads);
         }
       } else {
-        uiTransform(subvalue);
+        uiTransform(subvalue, rawPayloads);
       }
     }
   });

--- a/server/temporal-client/helpers.js
+++ b/server/temporal-client/helpers.js
@@ -56,7 +56,7 @@ const _uiTransformPayloadKeys = [
   _payloads,
 ];
 
-function uiTransform(item, rawPayloads=false) {
+function uiTransform(item, rawPayloads=false, transformingPayloads=false) {
   if (!item || typeof item !== 'object') {
     return item;
   }
@@ -79,6 +79,12 @@ function uiTransform(item, rawPayloads=false) {
         return;
       }
 
+      if (rawPayloads && transformingPayloads) {
+        item[subkey] = subvalue.toString('base64');
+
+        return;
+      }
+
       const stringval = subvalue.toString('utf8');
 
       try {
@@ -96,7 +102,9 @@ function uiTransform(item, rawPayloads=false) {
         item[subkey] = stringval;
       }
     } else if (Array.isArray(subvalue)) {
-      if (subkey === _payloads && !rawPayloads) {
+      if (subkey === _payloads && rawPayloads) {
+        subvalue.forEach(function(item) { uiTransform(item, rawPayloads, true) });
+      } else if (subkey === _payloads) {
         let payloads = [];
 
         Object.entries(subvalue).forEach(([subkey, payload]) => {
@@ -144,10 +152,10 @@ function uiTransform(item, rawPayloads=false) {
           });
           item[subkey] = values;
         } else {
-          uiTransform(subvalue, rawPayloads);
+          uiTransform(subvalue, rawPayloads, transformingPayloads);
         }
       } else {
-        uiTransform(subvalue, rawPayloads);
+        uiTransform(subvalue, rawPayloads, transformingPayloads);
       }
     }
   });

--- a/server/temporal-client/temporal-client.js
+++ b/server/temporal-client/temporal-client.js
@@ -18,7 +18,6 @@ function TemporalClient() {
     keepCase: false,
     longs: String,
     enums: String,
-    bytes: String,
     defaults: true,
     oneofs: true,
     includeDirs: [

--- a/server/temporal-client/temporal-client.js
+++ b/server/temporal-client/temporal-client.js
@@ -18,6 +18,7 @@ function TemporalClient() {
     keepCase: false,
     longs: String,
     enums: String,
+    bytes: String,
     defaults: true,
     oneofs: true,
     includeDirs: [
@@ -161,6 +162,7 @@ TemporalClient.prototype.getHistory = async function(
     nextPageToken,
     execution,
     waitForNewEvent,
+    rawPayloads,
     maximumPageSize = 100,
   }
 ) {
@@ -174,7 +176,7 @@ TemporalClient.prototype.getHistory = async function(
 
   let res = await this.client.getWorkflowExecutionHistoryAsync(ctx, req);
 
-  res = uiTransform(res);
+  res = uiTransform(res, rawPayloads);
 
   if (res.history && res.history.events) {
     res.history = buildHistory(res);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Adds support for performing data conversion via a websocket to a locally running `tctl`. 

Relies on the `tctl dataconverter web` command being worked on in: https://github.com/temporalio/temporal/pull/1437

``` bash
$ ./tctl dataconverter web http://temporal-ui.mycompany.com
Please follow this link for the web UI: http://temporal-ui.mycompany.com/data-converter/35949
```

Following the link configures the Web UI to send payloads to the local data converter for the rest of the session.
If the data-converter fails, the Web UI will fallback to the original payloads and show an error notification.

## Why?
<!-- Tell your future self why have you made these changes -->
This allows adding new/custom data converters using tctl plugins without having to use a customised Web UI server. For use cases such as encryption this allows decrypting payloads in the UI while keeping the encryption key secure on a user's laptop.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested manually using the cryptconverter sample in samples-go which produces encrypted payloads.

2. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Doc updates will be focused on the `tctl` command.