### PR TITLE
Address failures on query result payloads of type object

### DIFF
--- a/client/routes/workflow/helpers/get-query-result.js
+++ b/client/routes/workflow/helpers/get-query-result.js
@@ -1,5 +1,9 @@
 const getQueryResult = queryResponse => {
-  return { payloads: JSON.parse(queryResponse.payloads) };
+  if (typeof queryResponse?.payloads === 'string') {
+    return { payloads: JSON.parse(queryResponse.payloads) };
+  }
+
+  return queryResponse;
 };
 
 export { getQueryResult };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Prev change https://github.com/temporalio/web/pull/308/files#diff-b5b3d53036da20a76c4da6a6647b1ddacec5f88eed481f5e3178b1efeb110e35R111 made the `json/plain` payloads to be sent as object types to the client code, so that client code could prettify payloads on UI.
Sync Queries and Stack Trace  need to account for that

## Why?
<!-- Tell your future self why have you made these changes -->
Stack Trace and Queries were still trying to parse `json/plain` encoded payloads as json-string. This doesn't need to happen anymore as the response is already parsed

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
