### PR TITLE
Improve error visibility.

### DIFF
--- a/client/features/data-conversion.js
+++ b/client/features/data-conversion.js
@@ -1,6 +1,6 @@
 import WebSocketAsPromised from 'websocket-as-promised';
 
-export const decryptEventPayloads = async (events, port) => {
+export const convertEventPayloads = async (events, port) => {
   const sock = new WebSocketAsPromised(`ws://localhost:${port}/`, {
     packMessage: data => JSON.stringify(data),
     unpackMessage: data => JSON.parse(data),
@@ -27,14 +27,18 @@ export const decryptEventPayloads = async (events, port) => {
           sock
             .sendRequest({ payload: JSON.stringify(payload) })
             .then(response => {
-              payloads[i] = JSON.parse(response.content);
+              try {
+                payloads[i] = JSON.parse(response.content);
+              } catch {
+                payloads[i] = response.content;
+              }
             })
         );
       });
     });
     await Promise.all(requests);
   } catch (err) {
-    const message = `Unable to decrypt event payload: ${err}`;
+    const message = `Unable to convert event payload: ${err}`;
 
     return Promise.reject({ message });
   } finally {

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -77,7 +77,7 @@ import {
 import { NOTIFICATION_TYPE_ERROR } from '~constants';
 import { getErrorMessage } from '~helpers';
 import { NavigationBar, NavigationLink } from '~components';
-import { decryptEventPayloads } from '~features/data-encryption';
+import { convertEventPayloads } from '~features/data-conversion';
 
 export default {
   data() {
@@ -206,7 +206,7 @@ export default {
             return events;
           }
 
-          return decryptEventPayloads(events, port).catch(error => {
+          return convertEventPayloads(events, port).catch(error => {
             console.error(error);
 
             this.$emit('onNotification', {


### PR DESCRIPTION
## What was changed:
<!-- Describe what has changed in this PR -->
Converted content is shown if it cannot be parsed as JSON.

Refer to conversion not decryption. Conversion is the feature, decryption is a use case.

## Why?
<!-- Tell your future self why have you made these changes -->
This surfaces errors from ToString to the user to give a clue as to what might be wrong. Without this they just get a JSON parsing failed alert and see the unconverted payload. Aside from error handling we should not assume that ToString is going to give us JSON.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manually with cryptconverter sample.
