### PR TITLE
feat(client): add workflow-report-issue-url flag

### DIFF
--- a/client/components/feature-flag/helpers.js
+++ b/client/components/feature-flag/helpers.js
@@ -1,9 +1,15 @@
+const FLAG_WORKFLOW_REPORT_ISSUE_URL =
+  process.env.FLAG_WORKFLOW_REPORT_ISSUE_URL || '';
+const flagsFromEnv = {
+  'workflow-report-issue-url': FLAG_WORKFLOW_REPORT_ISSUE_URL,
+};
+
 export const isFlagEnabled = ({ flagHash = {}, name = '' }) =>
   flagHash[name] || false;
 
 export const mapFlagsToHash = (flagArray = []) => {
   return flagArray.reduce((accumulator, { key = '', value = false }) => {
-    accumulator[key] = value;
+    accumulator[key] = flagsFromEnv[key] || value;
 
     return accumulator;
   }, {});

--- a/client/feature-flags.json
+++ b/client/feature-flags.json
@@ -6,5 +6,9 @@
   {
     "key": "workflow-terminate",
     "value": true
+  },
+  {
+    "key": "workflow-report-issue-url",
+    "value": ""
   }
 ]

--- a/client/routes/workflow/helpers/get-summary-report-issue.js
+++ b/client/routes/workflow/helpers/get-summary-report-issue.js
@@ -1,0 +1,81 @@
+import featureFlags from '../../../feature-flags.json';
+import { mapFlagsToHash } from '../../../components/feature-flag/helpers';
+
+export function applyJiraFormat(md) {
+  return md
+    // Convert markdown code blocks to Jira-compatible
+    .replace(/```json/g, '{code:json}')
+    .replace(/```/g, '{code}')
+    // Convert markdown bold to Jira-compatible
+    .replace(/\*\*/g, '*')
+    // Remove heading since it goes under Jira ticket "Description"
+    .replace('*Description*\n', '');
+}
+
+export function getReportIssueLink({
+  workflow,
+  workflowId = '',
+  runId = '',
+  input = '',
+  result = '',
+  href = '',
+  flags,
+}) {
+  const flagHash = mapFlagsToHash(flags || featureFlags);
+  const reportIssueFlag = flagHash['workflow-report-issue-url'];
+
+  if (!(reportIssueFlag && workflow && input)) {
+    return '';
+  }
+
+  const title = encodeURIComponent(
+    `${workflow.workflowExecutionInfo.type.name} issue`
+  );
+  let body = `**Description**
+A clear and concise description
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Workflow ID**
+${workflowId}
+
+**Run ID**
+${runId}
+
+**Input**
+
+\`\`\`json
+${input}
+\`\`\`
+${result &&
+  `
+**Result**
+
+\`\`\`json
+${result}
+\`\`\`
+`.trim()}
+
+**Additional context**
+Add any other context about the problem here.
+
+**Link**
+${href}`;
+
+  // check if jira url, apply formatting
+  if (reportIssueFlag.toLowerCase().indexOf('atlassian.net') >= 0) {
+    body = applyJiraFormat(body);
+  }
+
+  return reportIssueFlag
+    .replace('$title', title)
+    .replace('$body', encodeURIComponent(body));
+}

--- a/client/routes/workflow/helpers/get-summary-report-issue.spec.js
+++ b/client/routes/workflow/helpers/get-summary-report-issue.spec.js
@@ -1,0 +1,164 @@
+import {
+  applyJiraFormat,
+  getReportIssueLink,
+} from './get-summary-report-issue';
+
+jest.mock('~helpers');
+
+const GH_ENCODED_BODY = `**Description**%0AA%20clear%20and%20concise%20description%0A%0A**To%20Reproduce**%0ASteps%20to%20reproduce%20the%20behavior%3A%0A1.%20Go%20to%20'...'%0A2.%20Click%20on%20'....'%0A3.%20Scroll%20down%20to%20'....'%0A4.%20See%20error%0A%0A**Expected%20behavior**%0AA%20clear%20and%20concise%20description%20of%20what%20you%20expected%20to%20happen.%0A%0A**Workflow%20ID**%0AworkflowIdValue%0A%0A**Run%20ID**%0ArunIdValue%0A%0A**Input**%0A%0A%60%60%60json%0A%7B%7D%0A%60%60%60%0A%0A**Result**%0A%0A%60%60%60json%0A%7B%7D%0A%60%60%60%0A%0A**Additional%20context**%0AAdd%20any%20other%20context%20about%20the%20problem%20here.%0A%0A**Link**%0Ahttp%3A%2F%2Flocalhost%3A8088%2Fnamespaces%2Fdefault%2Fworkflows%2FworkflowIdValue%2FrunIdValue`;
+// Apply Jira formatting
+const JIRA_ENCODED_BODY = applyJiraFormat(GH_ENCODED_BODY);
+
+describe('getReportIssueLink', () => {
+  describe('When no feature flag', () => {
+    it('should return an empty string.', () => {
+      const output = getReportIssueLink({
+        input: '{}',
+        result: '{}',
+        runId: 'runIdValue',
+        workflowId: 'workflowIdValue',
+        workflow: {
+          workflowExecutionInfo: {
+            type: { name: 'NamedWorkflow' },
+          },
+        },
+        flags: [
+          {
+            key: 'workflow-report-issue-url',
+            value: '',
+          },
+        ],
+      });
+
+      expect(output).toEqual('');
+    });
+  });
+
+  describe('When feature flag is set', () => {
+    let workflowId;
+    let baseUrl;
+    let runId;
+    let props;
+
+    beforeEach(() => {
+      baseUrl = 'https://github.com/temporalio/temporal/issues/new';
+      workflowId = 'workflowIdValue';
+      runId = 'runIdValue';
+      props = {
+        href: `http://localhost:8088/namespaces/default/workflows/${workflowId}/${runId}`,
+        input: '{}',
+        result: '{}',
+        workflow: {
+          workflowExecutionInfo: {
+            type: { name: 'NamedWorkflow' },
+          },
+        },
+        flags: [
+          {
+            key: 'workflow-report-issue-url',
+            value: baseUrl,
+          },
+        ],
+      };
+    });
+
+    describe('without template variables', () => {
+      it('should return as-is if it does not have templating variables.', () => {
+        expect(
+          getReportIssueLink({
+            runId,
+            workflowId,
+            href: props.href,
+            input: props.input,
+            result: props.result,
+            workflow: props.workflow,
+            flags: props.flags,
+          })
+        ).toEqual(baseUrl);
+      });
+    });
+
+    describe('github url with template variables', () => {
+      beforeEach(() => {
+        baseUrl = 'https://github.com/temporalio/temporal/issues/new';
+        props.flags[0].value = baseUrl;
+      });
+
+      it('should replace $title variable if set.', () => {
+        props.flags[0].value += '?template=bug_report.md&title=$title';
+        expect(
+          getReportIssueLink({
+            runId,
+            workflowId,
+            href: props.href,
+            input: props.input,
+            result: props.result,
+            workflow: props.workflow,
+            flags: props.flags,
+          })
+        ).toEqual(
+          'https://github.com/temporalio/temporal/issues/new?template=bug_report.md&title=NamedWorkflow%20issue'
+        );
+      });
+
+      it('should replace $body variable if set.', () => {
+        props.flags[0].value +=
+          '?template=bug_report.md&title=$title&body=$body';
+        expect(
+          getReportIssueLink({
+            runId,
+            workflowId,
+            href: props.href,
+            input: props.input,
+            result: props.result,
+            workflow: props.workflow,
+            flags: props.flags,
+          })
+        ).toEqual(
+          `https://github.com/temporalio/temporal/issues/new?template=bug_report.md&title=NamedWorkflow%20issue&body=${GH_ENCODED_BODY}`
+        );
+      });
+    });
+
+    describe('jira url with template variables', () => {
+      beforeEach(() => {
+        baseUrl =
+          'https://example.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10000&issuetype=10010&summary=$title';
+        props.flags[0].value = baseUrl;
+      });
+
+      it('should replace $title variable if set.', () => {
+        expect(
+          getReportIssueLink({
+            runId,
+            workflowId,
+            href: props.href,
+            input: props.input,
+            result: props.result,
+            workflow: props.workflow,
+            flags: props.flags,
+          })
+        ).toEqual(
+          'https://example.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10000&issuetype=10010&summary=NamedWorkflow%20issue'
+        );
+      });
+
+      it('should replace $body variable if set.', () => {
+        props.flags[0].value += '&description=$body';
+        expect(
+          getReportIssueLink({
+            runId,
+            workflowId,
+            href: props.href,
+            input: props.input,
+            result: props.result,
+            workflow: props.workflow,
+            flags: props.flags,
+          })
+        ).toEqual(
+          `https://example.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10000&issuetype=10010&summary=NamedWorkflow%20issue&description=${JIRA_ENCODED_BODY}`
+        );
+      });
+    });
+  });
+});

--- a/client/routes/workflow/helpers/get-summary-report-issue.spec.js
+++ b/client/routes/workflow/helpers/get-summary-report-issue.spec.js
@@ -5,9 +5,9 @@ import {
 
 jest.mock('~helpers');
 
-const GH_ENCODED_BODY = `**Description**%0AA%20clear%20and%20concise%20description%0A%0A**To%20Reproduce**%0ASteps%20to%20reproduce%20the%20behavior%3A%0A1.%20Go%20to%20'...'%0A2.%20Click%20on%20'....'%0A3.%20Scroll%20down%20to%20'....'%0A4.%20See%20error%0A%0A**Expected%20behavior**%0AA%20clear%20and%20concise%20description%20of%20what%20you%20expected%20to%20happen.%0A%0A**Workflow%20ID**%0AworkflowIdValue%0A%0A**Run%20ID**%0ArunIdValue%0A%0A**Input**%0A%0A%60%60%60json%0A%7B%7D%0A%60%60%60%0A%0A**Result**%0A%0A%60%60%60json%0A%7B%7D%0A%60%60%60%0A%0A**Additional%20context**%0AAdd%20any%20other%20context%20about%20the%20problem%20here.%0A%0A**Link**%0Ahttp%3A%2F%2Flocalhost%3A8088%2Fnamespaces%2Fdefault%2Fworkflows%2FworkflowIdValue%2FrunIdValue`;
+const GH_ENCODED_BODY = `**Description**%0AA%20clear%20and%20concise%20description%0A%0A**To%20Reproduce**%0ASteps%20to%20reproduce%20the%20behavior%3A%0A1.%20Go%20to%20'...'%0A2.%20Click%20on%20'....'%0A3.%20Scroll%20down%20to%20'....'%0A4.%20See%20error%0A%0A**Expected%20behavior**%0AA%20clear%20and%20concise%20description%20of%20what%20you%20expected%20to%20happen.%0A%0A**Workflow%20ID**%0AworkflowIdValue%0A%0A**Run%20ID**%0ArunIdValue%0A%0A**Input**%0A%0A%60%60%60json%0A%7B%7D%0A%60%60%60%0A**Result**%0A%0A%60%60%60json%0A%7B%7D%0A%60%60%60%0A%0A**Additional%20context**%0AAdd%20any%20other%20context%20about%20the%20problem%20here.%0A%0A**Link**%0Ahttp%3A%2F%2Flocalhost%3A8088%2Fnamespaces%2Fdefault%2Fworkflows%2FworkflowIdValue%2FrunIdValue`;
 // Apply Jira formatting
-const JIRA_ENCODED_BODY = applyJiraFormat(GH_ENCODED_BODY);
+const JIRA_ENCODED_BODY = encodeURIComponent(applyJiraFormat(decodeURIComponent(GH_ENCODED_BODY)));
 
 describe('getReportIssueLink', () => {
   describe('When no feature flag', () => {

--- a/client/routes/workflow/helpers/index.js
+++ b/client/routes/workflow/helpers/index.js
@@ -4,6 +4,7 @@ export { default as getEventSummary } from './get-event-summary';
 export { default as getHistoryEvents } from './get-history-events';
 export { default as getHistoryTimelineEvents } from './get-history-timeline-events';
 export { default as getSummary } from './get-summary';
+export { getReportIssueLink } from './get-summary-report-issue';
 export { default as getSummaryWorkflowStatus } from './get-summary-workflow-status';
 export { default as getTimeElapsedDisplay } from './get-time-elapsed-display';
 export { default as getTimeStampDisplay } from './get-time-stamp-display';

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -12,6 +12,11 @@
           Terminate
         </a>
       </feature-flag>
+      <feature-flag name="workflow-report-issue-url">
+        <a :href="reportWorkflowIssueLink" class="report-issue" target="_blank">
+          Report Issue
+        </a>
+      </feature-flag>
     </aside>
 
     <modal name="confirm-termination">
@@ -155,10 +160,11 @@
 </template>
 
 <script>
+import { getReportIssueLink } from './helpers';
 import { TERMINATE_DEFAULT_ERROR_MESSAGE } from './constants';
 import { NOTIFICATION_TYPE_ERROR, NOTIFICATION_TYPE_SUCCESS } from '~constants';
-import { getErrorMessage } from '~helpers';
 import { BarLoader, DataViewer, DetailList, FeatureFlag } from '~components';
+import { getErrorMessage } from '~helpers';
 
 export default {
   data() {
@@ -206,6 +212,16 @@ export default {
     },
     showTerminate() {
       return this.isWorkflowRunning && this.webSettingsCache?.permitWriteApi;
+    },
+    reportWorkflowIssueLink() {
+      return getReportIssueLink({
+        workflow: this.workflow,
+        workflowId: this.workflowId,
+        runId: this.runId,
+        input: JSON.stringify(this.input, null, 2),
+        result: JSON.stringify(this.resultView, null, 2),
+        href: window.location.href,
+      });
     },
   },
   methods: {
@@ -290,8 +306,20 @@ section.workflow-summary
     max-height 18vh
 
   aside.actions
-    float right
-    a
+    width 100%
+    display flex
+    position absolute
+    justify-content flex-end
+    right 18px
+
+    a.report-issue
+      action-button(uber-white-120)
+      margin-left 16px
+      text-align center
+
+      &::after
+        content ''
+    a.terminate
       action-button(uber-orange)
 
 [data-modal="confirm-termination"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.TEMPORAL_WEB_ROOT_PATH': `"${PUBLIC_PATH}"`,
+      'process.env.FLAG_WORKFLOW_REPORT_ISSUE_URL': `"${process.env.FLAG_WORKFLOW_REPORT_ISSUE_URL}"`,
     }),
     new ExtractTextPlugin({
       filename: development ? 'temporal.css' : 'temporal.[hash].css',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:

Added a `workflow-report-issue-url` feature flag and `FLAG_WORKFLOW_REPORT_ISSUE_URL` environment variable for reporting issues on specific workflow

## Why?

When there's an issue with a running, terminated or completed workflow, it's very common to pull information about the workflow/run into a ticket and this PR aims to make that process easier

<img width="2632" alt="Github report issue" src="https://user-images.githubusercontent.com/1026125/116937372-fc308780-ac1d-11eb-92db-42e1041237ab.png">
<img width="2127" alt="Jira report issue" src="https://user-images.githubusercontent.com/1026125/116937382-ff2b7800-ac1d-11eb-9b13-ab6ba51f6fae.png">


## Checklist

1. How was this tested:

Run command to add env var for flag

`export FLAG_WORKFLOW_REPORT_ISSUE_URL=https://github.com/temporalio/web/issues/new?title=\$title\&body=\$body`

Run development server (and `temporalio/docker-compose`)

`npm run dev`

Use `temporalio/samples-go` to start a workflow, go to localhost, select a namespace and workflow then click "Report Issue"