### PR TITLE
Show pending activitties as History events

### DIFF
--- a/client/routes/workflow/helpers/get-events-from-pending-activity.js
+++ b/client/routes/workflow/helpers/get-events-from-pending-activity.js
@@ -1,0 +1,18 @@
+const getEventsFromPendingActivity = (activities, idOffset) => {
+  if (!activities) {
+    return [];
+  }
+
+  if (Number.isInteger(idOffset)) {
+    idOffset = Number(idOffset);
+  }
+
+  return activities.map((a, i) => ({
+    details: a,
+    eventId: idOffset + i + 1,
+    eventTime: a.scheduledTime,
+    eventType: 'ActivityTaskStarted',
+  }));
+};
+
+export default getEventsFromPendingActivity;

--- a/client/routes/workflow/helpers/get-events-from-pending-activity.js
+++ b/client/routes/workflow/helpers/get-events-from-pending-activity.js
@@ -3,7 +3,6 @@ const getEventsFromPendingActivity = (activities, idOffset) => {
     return [];
   }
 
-
   return activities.map((a, i) => ({
     details: a,
     eventId: idOffset + i + 1,

--- a/client/routes/workflow/helpers/get-events-from-pending-activity.js
+++ b/client/routes/workflow/helpers/get-events-from-pending-activity.js
@@ -3,9 +3,6 @@ const getEventsFromPendingActivity = (activities, idOffset) => {
     return [];
   }
 
-  if (Number.isInteger(idOffset)) {
-    idOffset = Number(idOffset);
-  }
 
   return activities.map((a, i) => ({
     details: a,

--- a/client/routes/workflow/helpers/index.js
+++ b/client/routes/workflow/helpers/index.js
@@ -1,6 +1,7 @@
 export { default as getEventDetails } from './get-event-details';
 export { default as getEventFullDetails } from './get-event-full-details';
 export { default as getEventSummary } from './get-event-summary';
+export { default as getEventsFromPendingActivity } from './get-events-from-pending-activity';
 export { default as getHistoryEvents } from './get-history-events';
 export { default as getHistoryTimelineEvents } from './get-history-timeline-events';
 export { default as getSummary } from './get-summary';

--- a/client/routes/workflow/history.vue
+++ b/client/routes/workflow/history.vue
@@ -313,6 +313,7 @@ export default {
     'runId',
     'showGraph',
     'timelineEvents',
+    'pendingEvents',
     'workflowId',
   ],
   created() {
@@ -356,8 +357,9 @@ export default {
       }.json`;
     },
     filteredEvents() {
-      const { eventId, eventType } = this;
-      const formattedEvents = this.events.map(event => ({
+      const { eventId, eventType, pendingEvents } = this;
+      const events = [...this.events, ...pendingEvents];
+      const formattedEvents = events.map(event => ({
         ...event,
         expanded: event.eventId === eventId,
       }));

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -45,6 +45,7 @@
       name="history"
       :baseAPIURL="baseAPIURL"
       :events="history.events"
+      :pendingEvents="history.pendingEvents"
       :loading="history.loading"
       :timelineEvents="history.timelineEvents"
       @onNotification="onNotification"
@@ -73,6 +74,7 @@ import {
   getHistoryEvents,
   getHistoryTimelineEvents,
   getSummary,
+  getEventsFromPendingActivity,
 } from './helpers';
 import { NOTIFICATION_TYPE_ERROR } from '~constants';
 import { getErrorMessage } from '~helpers';
@@ -92,6 +94,7 @@ export default {
 
       history: {
         events: [],
+        pendingEvents: [],
         loading: undefined,
         timelineEvents: [],
       },
@@ -225,6 +228,13 @@ export default {
           this.events = this.events.concat(events);
 
           this.history.events = getHistoryEvents(this.events);
+          this.history.pendingEvents = getHistoryEvents(
+            getEventsFromPendingActivity(
+              this.workflow.pendingActivities,
+              this.history.events.length
+            )
+          );
+
           this.history.timelineEvents = getHistoryTimelineEvents(
             this.history.events
           );


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Pending Activities are now shown on History page as ActivityTaskStarted event
![image](https://user-images.githubusercontent.com/11838981/116956522-4def0700-ac4a-11eb-91a7-af4bdd8a8793.png)

## Why?
<!-- Tell your future self why have you made these changes -->
Makes it easier for users to see what's the state of workflow is, when activity tasks are being executed. The issue was coming because ActivityTaskStarted event is not added to history until the task is completed. 
The change takes pending activities and shows them as ActivityTaskStarted events in history

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
