### PR TITLE
fix(client): namespace/navigation bar opacity

### DIFF
--- a/client/components/navigation-bar.vue
+++ b/client/components/navigation-bar.vue
@@ -15,5 +15,6 @@ export default {
   flex-wrap: wrap;
   background-color: #000;
   padding: 0 12px;
+  opacity: 0.7;
 }
 </style>

--- a/client/components/navigation-bar.vue
+++ b/client/components/navigation-bar.vue
@@ -15,6 +15,5 @@ export default {
   flex-wrap: wrap;
   background-color: #000;
   padding: 0 12px;
-  opacity: 0.7;
 }
 </style>

--- a/client/styles/code.styl
+++ b/client/styles/code.styl
@@ -34,9 +34,6 @@ code[class*="language-"] ::selection
   &.entity
     cursor help
 
-.namespace
-  opacity .7
-
 .token.property
 .token.tag
 .token.constant


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Remove the `opacity: 0.7` from `.namespace` (which encapsulates the `workflow-list` components) and put it just on the `navigation-bar`

## Why?
It can be hard to read info on the `workflow-list` since the contrast is pretty low

**Before**

![image](https://user-images.githubusercontent.com/1026125/117195176-d29c6b00-ad99-11eb-8f0e-f0fdedd0616c.png)

**After**
![image](https://user-images.githubusercontent.com/1026125/117195147-ca443000-ad99-11eb-8266-1134162e1b3f.png)

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
