### PR TITLE
Make history events expandable on summary page

### DIFF
--- a/client/routes/workflow/helpers/get-events-from-pending-activity.js
+++ b/client/routes/workflow/helpers/get-events-from-pending-activity.js
@@ -5,7 +5,7 @@ const getEventsFromPendingActivity = (activities, idOffset) => {
 
   return activities.map((a, i) => ({
     details: a,
-    eventId: idOffset + i + 1,
+    eventId: (idOffset + i + 1).toString(),
     eventTime: a.scheduledTime,
     eventType: 'ActivityTaskStarted',
   }));

--- a/client/routes/workflow/history.vue
+++ b/client/routes/workflow/history.vue
@@ -357,11 +357,11 @@ export default {
       }.json`;
     },
     filteredEvents() {
-      const { eventId, eventType, pendingEvents } = this;
+      const { eventIdStr, eventType, pendingEvents } = this;
       const events = [...this.events, ...pendingEvents];
       const formattedEvents = events.map(event => ({
         ...event,
-        expanded: event.eventId === eventId,
+        expanded: event.eventId === eventIdStr,
       }));
 
       return eventType && eventType !== 'All'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Clicking on summary events expands them and shows details. 
![image](https://user-images.githubusercontent.com/11838981/117194248-b815c200-ad98-11eb-88d1-761b278b250a.png)

This is done by changing the eventId query parameter type from int to string, because `grpc` lib converts proto int64 fiields into strings, such as below becomes a string
```
message HistoryEvent {
    int64 event_id = 1;
```

## Why?
<!-- Tell your future self why have you made these changes -->
Makes the summary events expand on clicking

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- Open any workflow -> grid -> Summary
- Click on any event
- expected: Event expands and shows details

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No