### PR TITLE
Fix cicd pipeline false negative

### DIFF
--- a/cypress/integration/workflow-summary.spec.js
+++ b/cypress/integration/workflow-summary.spec.js
@@ -7,6 +7,7 @@ context('Workflow Summary', () => {
         'namespace_id'
       )}/workflows?range=last-5-days&status=ALL`
     );
+    cy.wait(1000);
   });
 
   it('renders workflow summary', () => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Added short sleeping in workflow cicd tests to ensure all data is fetched before examining

## Why?
<!-- Tell your future self why have you made these changes -->
Due to workflows fetching changes, the UI now updates more often than before. It now renders open workflows and continues to fetch closed workflows. The sleep ensures the test doesn't try to find a workflow in the list of the first results and waits until more workflows are rendered

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Ran the cicd tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No