### PR TITLE
Show search attribute keys in history

### DIFF
--- a/server/temporal-client/helpers.js
+++ b/server/temporal-client/helpers.js
@@ -136,11 +136,11 @@ function uiTransform(item, rawPayloads=false, transformingPayloads=false) {
     } else if (subvalue && typeof subvalue === 'object') {
       if (_uiTransformPayloadKeys.includes(subkey)) {
         if (subkey === _searchAttributes) {
-          let values = [];
+          const values = {};
 
           Object.entries(subvalue.indexedFields).forEach(
             ([subkey, subvalue]) => {
-              values = [...values, subvalue.data.toString('utf8')];
+              values[subkey] = subvalue.data.toString('utf8');
             }
           );
           item[subkey] = values;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Made the search attribute keys show up in the UI
![image](https://user-images.githubusercontent.com/11838981/117382440-5e45f280-ae93-11eb-997c-74fe11d02267.png)

## Why?
<!-- Tell your future self why have you made these changes -->
The keys were getting lost and replaced by array index

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
