### PR TITLE
Expose control over gRPC max message length

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,10 @@
       "runtimeArgs": ["run-script", "dev"],
       "runtimeExecutable": "npm",
       "skipFiles": ["<node_internals>/**"],
-      "type": "pwa-node"
+      "type": "pwa-node",
+      "env": {
+        "TEMPORAL_GRPC_MAX_MESSAGE_LENGTH": "6194304"
+      }
     },
     {
       "name": "Debug with mTLS",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Set these environment variables if you need to change their defaults
 | TEMPORAL_HOT_RELOAD_TEST_PORT | HTTP port used by hot reloading in tests                          | 8082                          |
 | TEMPORAL_SESSION_SECRET       | Secret used to hash the session with HMAC                         | "ensure secret in production" |
 | TEMPORAL_EXTERNAL_SCRIPTS     | Additional JavaScript tags to serve in the UI                     |                               |
+| TEMPORAL_GRPC_MAX_MESSAGE_LENGTH | gRPC max message length (bytes)                                | 4194304 (4mb)                 |
 
 <details>
 <summary>

--- a/server/temporal-client/temporal-client.js
+++ b/server/temporal-client/temporal-client.js
@@ -44,6 +44,9 @@ function TemporalClient() {
 
   const { credentials: tlsCreds, options: tlsOpts } = getCredentials();
 
+  tlsOpts['grpc.max_receive_message_length'] =
+    Number(process.env.TEMPORAL_GRPC_MAX_MESSAGE_LENGTH) || 4 * 1024 * 1024;
+
   let client = new service.temporal.api.workflowservice.v1.WorkflowService(
     process.env.TEMPORAL_GRPC_ENDPOINT || '127.0.0.1:7233',
     tlsCreds,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Adds env flag to change the gRPC max message length limit

## Why?
<!-- Tell your future self why have you made these changes --> 
Gives users an option to display gRPC responses bigger than 4mb (default grpc message receive length limit).
Useful with APIs `ListOpenWorkflowExecutions`, `ListClosedWorkflowExecutions` and `GetWorkflowExecutionHistory`

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- Run `largepayloads` fixture from samples-go
- Open workflows page on Web UI
- expected: workflows are shown
- prior behavior: error message `8 RESOURCE_EXHAUSTED: Received message larger than max (5243864 vs. 4194304)`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Updated README