### PR TITLE
Add readme sample for web root path variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Set these environment variables if you need to change their defaults
 | TEMPORAL_WEB_PORT             | HTTP port to serve on                                             | 8088                          |
 | TEMPORAL_CONFIG_PATH          | Path to config file, see [configurations](#configuring-authentication-optional) | ./server/config.yml |
 | TEMPORAL_PERMIT_WRITE_API     | Boolean to permit write API methods such as Terminating Workflows | true                          |
-| TEMPORAL_WEB_ROOT_PATH        | The root path to serve the app under                              | /                             |
+| TEMPORAL_WEB_ROOT_PATH        | The root path to serve the app under. Ex. "/test/"                | /                             |
 | TEMPORAL_HOT_RELOAD_PORT      | HTTP port used by hot reloading in development                    | 8081                          |
 | TEMPORAL_HOT_RELOAD_TEST_PORT | HTTP port used by hot reloading in tests                          | 8082                          |
 | TEMPORAL_SESSION_SECRET       | Secret used to hash the session with HMAC                         | "ensure secret in production" |


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds readme sample of `TEMPORAL_WEB_ROOT_PATH` value

## Why?
<!-- Tell your future self why have you made these changes -->
Web root path works only if passed in format with forward slashes on both sides. This value is passed to koa-router, webpack and used in http.js. 

Another option would be to do custom processing and modify the value so it fits the format.
The below regex can be used to trim forward slashes on both ends of the path. Then the resulting value can be passed to koa-router, webpack and http.js according to their expected format (adding forward slashes if needed). Having slashes on both sides works for all places 
``` js
"/test/root/path/".replace(/(^\/|\/$)/, '')
```

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Ran with `TEMPORAL_WEB_ROOT_PATH` set to `"/test/"`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No