### PR TITLE
Fix workfow Summary not showing if history call fails

### DIFF
--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -286,6 +286,11 @@ export default {
             this.workflow = wf;
             this.isWorkflowRunning = !wf.workflowExecutionInfo.closeTime;
             this.baseApiUrlRetryCount = 0;
+            this.summary = getSummary({
+              events: this.events,
+              isWorkflowRunning: this.isWorkflowRunning,
+              workflow: this.workflow,
+            });
           },
           error => {
             this.$emit('onNotification', {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Makes workflow summary page render as long as WorkflowDetails api call succeeds

## Why?
<!-- Tell your future self why have you made these changes -->
Summary page would show a blank page if Workflow History api call returned error 

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Artificially throwing an error in `temporal-client.js -> getHistory()`. Validating that the summary page still renders workflow details

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No