### PR TITLE
Fix custom root path feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN npm install --production
 # Bundle app source
 COPY . .
 # Bundle the client code
+ENV TEMPORAL_WEB_ROOT_PATH=/
+# ENV TEMPORAL_WEB_ROOT_PATH=/custom-path-example/
 RUN npm run build-production
 
 
@@ -23,5 +25,7 @@ COPY --from=builder ./usr/build ./
 
 ENV NODE_ENV=production
 ENV NPM_CONFIG_PRODUCTION=true
+ENV TEMPORAL_WEB_ROOT_PATH=/
+# ENV TEMPORAL_WEB_ROOT_PATH=/custom-path-example/
 EXPOSE 8088
 CMD [ "node", "server.js" ]

--- a/server/index.js
+++ b/server/index.js
@@ -91,7 +91,7 @@ app.init = function(options) {
             ctx.set('content-type', 'text/html');
             ctx.body = compiler.outputFileSystem.readFileSync(filename);
           } else {
-            done = await send(ctx, 'index.html', { root: staticRoot });
+            done = await send(ctx, 'index.html', { root: path.join(staticRoot, PUBLIC_PATH) });
           }
         } catch (err) {
           if (err.status !== 404) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,9 +17,9 @@ module.exports = {
       __dirname,
       process.env.TEST_RUN ? 'client/test/index' : 'client/main'
     ),
-  ].filter((x) => x),
+  ].filter(x => x),
   output: {
-    path: path.join(__dirname, 'dist'),
+    path: path.join(__dirname, 'dist', PUBLIC_PATH),
     filename: 'temporal.[hash].js',
     publicPath: PUBLIC_PATH,
   },
@@ -40,9 +40,9 @@ module.exports = {
       lang: 'en-US',
       scripts: (process.env.TEMPORAL_EXTERNAL_SCRIPTS || '')
         .split(',')
-        .filter((x) => x),
+        .filter(x => x),
     }),
-  ].filter((x) => x),
+  ].filter(x => x),
   module: {
     rules: [
       {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fixes custom root path feature `TEMPORAL_WEB_ROOT_PATH` in prod build. 
Client static files will now be placed under the specified subpath in `dist` folder:
 ```
/usr/app # cd dist/
/usr/app/dist # ls custom-path-example/*
custom-path-example/favicon.png                            custom-path-example/temporal.c502a579d6c1648a6205.css.map
custom-path-example/index.html                             custom-path-example/temporal.c502a579d6c1648a6205.js
custom-path-example/logo-rounded.png                       custom-path-example/temporal.c502a579d6c1648a6205.js.map
custom-path-example/temporal.c502a579d6c1648a6205.css
/usr/app/dist # 
```

Serving the static files from server/index.js will also include the subpath 

## Why?
<!-- Tell your future self why have you made these changes -->
Fixes the feature

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
