### PR TITLE
Properly process expiration time

### DIFF
--- a/client/constants.js
+++ b/client/constants.js
@@ -43,3 +43,4 @@ export const NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT =
 export const NOTIFICATION_TYPE_SUCCESS = 'success';
 export const NOTIFICATION_TYPE_WARNING = 'warning';
 export const NOTIFICATION_TIMEOUT = 5000;
+export const NO_EXPIRATION_TIMEOUT = 1969;

--- a/client/helpers/get-key-value-pairs.js
+++ b/client/helpers/get-key-value-pairs.js
@@ -53,6 +53,17 @@ const getKeyValuePairs = event => {
           routeLink: value.routeLink,
           value: value.text,
         });
+      } else if (key === 'expirationTime') {
+        const val = timestampToDate(value);
+
+        if (!val || !val.isValid()) {
+          return;
+        }
+
+        kvps.push({
+          key,
+          value: val.year() === 1969 ? '' : val.format('lll'), // 1969 corresponds to no expiration timeout
+        });
       } else if (value.duration !== undefined) {
         kvps.push({
           key,
@@ -101,7 +112,7 @@ const getKeyValuePairs = event => {
         });
       } else if (key === 'scheduledTime') {
         kvps.push({ key, value: scheduledTimeView(value) });
-      } else if (key === 'lastHeartbeatTime') {
+      } else if (['lastStartedTime', 'lastHeartbeatTime'].includes(key)) {
         kvps.push({ key, value: timestampToDate(value).format('lll') });
       } else if (key === 'taskQueue.name' || key === 'Taskqueue') {
         kvps.push({

--- a/client/helpers/get-key-value-pairs.js
+++ b/client/helpers/get-key-value-pairs.js
@@ -1,5 +1,10 @@
 import moment from 'moment';
-import { failureKeys, jsonKeys, preKeys } from '~constants';
+import {
+  failureKeys,
+  jsonKeys,
+  preKeys,
+  NO_EXPIRATION_TIMEOUT,
+} from '~constants';
 import { timestampToDate } from '~helpers';
 
 function failureToString(failure) {
@@ -37,6 +42,26 @@ const scheduledTimeView = time => {
   return res;
 };
 
+const expirationTimeoutView = val => {
+  if (!val) {
+    return;
+  }
+
+  if (!val.year) {
+    return;
+  }
+
+  if (!val.format) {
+    return;
+  }
+
+  if (val.year() === NO_EXPIRATION_TIMEOUT) {
+    return '';
+  }
+
+  return val.format('lll');
+};
+
 const getKeyValuePairs = event => {
   const kvps = [];
   const flatten = (prefix, obj, root) => {
@@ -56,13 +81,9 @@ const getKeyValuePairs = event => {
       } else if (key === 'expirationTime') {
         const val = timestampToDate(value);
 
-        if (!val || !val.isValid()) {
-          return;
-        }
-
         kvps.push({
           key,
-          value: val.year() === 1969 ? '' : val.format('lll'), // 1969 corresponds to no expiration timeout
+          value: expirationTimeoutView(val),
         });
       } else if (value.duration !== undefined) {
         kvps.push({


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Improved processing of activity expiration time that was showing negative numbers when the value actually corresponded to expiration time not set 

before:
![image](https://user-images.githubusercontent.com/11838981/121224237-356f9f00-c83d-11eb-8f38-1b0ae942fe40.png)

after:
![image](https://user-images.githubusercontent.com/11838981/121224292-43252480-c83d-11eb-8481-8403bad1f292.png)

## Why?
<!-- Tell your future self why have you made these changes -->
Fixes an issue of showing unset expiration time as `-17259888h`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No