### PR TITLE
fix(test): Explicitly set timezone for unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "NODE_ENV=development node server.js",
     "eslint": "eslint --ext .js,.vue client --fix",
     "start": "npm run build && NODE_ENV=production node server.js",
-    "test:unit": "jest",
+    "test:unit": "TZ=utc jest",
     "test:ci": "cypress run --headless --quiet",
     "build": "webpack",
     "build-production": "NODE_ENV=production npm run build"


### PR DESCRIPTION
This allows all tests to complete successfully without setting the machine TZ.

## What was changed
Setting the TZ environment variable during the `test` command.

## Why?
The current test behavior expects the machine to be on UTC TZ, and tests will fail otherwise. 

2. How was this tested:
Running the tests on `America/Los_Angeles`.