### PR TITLE
Show no stack trace available message for complete workflows

### DIFF
--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -56,6 +56,7 @@
       :baseAPIURL="baseAPIURL"
       :taskQueueName="taskQueue.name"
       :isWorkerRunning="isWorkerRunning"
+      :isWorkflowRunning="this.summary.isWorkflowRunning"
       @onNotification="onNotification"
     />
     <router-view


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added No Stack Trace available message if workflow is not running
![image](https://user-images.githubusercontent.com/11838981/125141342-a1a62280-e0c9-11eb-9056-fde87306ed5a.png)

## Why?
<!-- Tell your future self why have you made these changes -->
Clear message instead of empty stack trace

Additionally if there are Workers running: 
 - prevents unnecessarily pending for stack trace if workflow is ~complete and immediately let's user know stack trace is not available. (pending was taking many seconds until context would deadline and error message show up)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
