### PR TITLE
Add timestamp to console log

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ const Koa = require('koa'),
   csrf = require('koa-csrf'),
   auth = require('./auth'),
   { securityHeaders } = require('./middlewares'),
-  { logger } = require('./logger');
+  logger = require('./logger');
 
 app.webpackConfig = require('../webpack.config');
 

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,8 @@ const Koa = require('koa'),
   passport = require('passport'),
   csrf = require('koa-csrf'),
   auth = require('./auth'),
-  { securityHeaders } = require('./middlewares');
+  { securityHeaders } = require('./middlewares'),
+  { logger } = require('./logger');
 
 app.webpackConfig = require('../webpack.config');
 
@@ -45,7 +46,7 @@ app.init = function(options) {
           options.logErrors !== false &&
           (typeof err.statusCode !== 'number' || err.statusCode >= 500)
         ) {
-          console.error(err);
+          logger.error(err);
         }
         ctx.status = err.statusCode || err.status || 500;
         ctx.body = { message: err.message };

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,0 +1,20 @@
+class Logger {
+  ts = () => {
+    return '[' + new Date().toISOString() + '] ';
+  };
+
+  log(...data) {
+    console.log(this.ts(), ...data);
+  }
+  warn(...data) {
+    console.warn(this.ts(), ...data);
+  }
+  error(...data) {
+    console.error(this.ts(), ...data);
+  }
+  debug(...data) {
+    console.debug(this.ts(), ...data);
+  }
+}
+
+module.exports = { logger: new Logger() };

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,20 +1,14 @@
-class Logger {
-  ts = () => {
-    return '[' + new Date().toISOString() + '] ';
-  };
+const timeStamp = () => '[' + new Date().toISOString() + ']';
 
-  log(...data) {
-    console.log(this.ts(), ...data);
-  }
-  warn(...data) {
-    console.warn(this.ts(), ...data);
-  }
-  error(...data) {
-    console.error(this.ts(), ...data);
-  }
-  debug(...data) {
-    console.debug(this.ts(), ...data);
-  }
-}
+const withTimestamp = (fn, ...args) => {
+  return fn.call(null, timeStamp(), ...args);
+};
 
-module.exports = { logger: new Logger() };
+const logger = {
+  log: (...args) => withTimestamp(console.log, ...args),
+  warn: (...args) => withTimestamp(console.warn, ...args),
+  error: (...args) => withTimestamp(console.error, ...args),
+  debug: (...args) => withTimestamp(console.debug, ...args),
+};
+
+module.exports = logger;

--- a/server/temporal-client/helpers.js
+++ b/server/temporal-client/helpers.js
@@ -1,6 +1,7 @@
 const Long = require('long');
 const losslessJSON = require('lossless-json');
 const moment = require('moment');
+const { logger } = require('../logger')
 
 function buildHistory(getHistoryRes) {
   const history = getHistoryRes.history;
@@ -130,7 +131,7 @@ function uiTransform(item, rawPayloads = false, transformingPayloads = false) {
 
             payloads = [...payloads, data];
           } catch (error) {
-            console.log(
+            logger.log(
               `Unable to process payload. Encoding: ${encoding}, data: ${data}. ${error}`
             );
             payloads = [...payloads, data.toString()];

--- a/server/temporal-client/helpers.js
+++ b/server/temporal-client/helpers.js
@@ -1,7 +1,7 @@
 const Long = require('long');
 const losslessJSON = require('lossless-json');
 const moment = require('moment');
-const { logger } = require('../logger')
+const logger = require('../logger')
 
 function buildHistory(getHistoryRes) {
   const history = getHistoryRes.history;

--- a/server/tls/tls.js
+++ b/server/tls/tls.js
@@ -3,6 +3,7 @@ const { readCredsFromCertFiles } = require('./read-creds-from-cert-files');
 const { readCredsFromConfig } = require('./read-creds-from-config');
 const { compareCaseInsensitive } = require('../utils');
 const { getTlsConfig } = require('../config');
+const { logger } = require('../logger')
 
 const keyPath = process.env.TEMPORAL_TLS_KEY_PATH;
 const certPath = process.env.TEMPORAL_TLS_CERT_PATH;
@@ -14,7 +15,7 @@ const verifyHost = [true, 'true', undefined].includes(
 const tlsConfigFile = getTlsConfig()
 function getCredentials() {
   if (keyPath !== undefined && certPath !== undefined) {
-    console.log('establishing secure connection using TLS cert files...');
+    logger.log('establishing secure connection using TLS cert files...');
     const { pk, cert, ca } = readCredsFromCertFiles({
       keyPath,
       certPath,
@@ -22,17 +23,17 @@ function getCredentials() {
     });
     return createSecure(pk, cert, ca, serverName, verifyHost);
   } else if (caPath !== undefined) {
-    console.log('establishing server-side TLS connection using only TLS CA file...');
+    logger.log('establishing server-side TLS connection using only TLS CA file...');
     const { ca } = readCredsFromCertFiles({ caPath });
     return createSecure(undefined, undefined, ca, serverName, verifyHost);
   } else if (tlsConfigFile.key) {
-    console.log(
+    logger.log(
       'establishing secure connection using TLS yml configuration...'
     );
     const { pk, cert, ca, serverName, verifyHost } = readCredsFromConfig();
     return createSecure(pk, cert, ca, serverName, verifyHost);
   } else {
-    console.log('establishing insecure connection...');
+    logger.log('establishing insecure connection...');
     return { credentials: grpc.credentials.createInsecure(), options: {} };
   }
 }

--- a/server/tls/tls.js
+++ b/server/tls/tls.js
@@ -3,7 +3,7 @@ const { readCredsFromCertFiles } = require('./read-creds-from-cert-files');
 const { readCredsFromConfig } = require('./read-creds-from-config');
 const { compareCaseInsensitive } = require('../utils');
 const { getTlsConfig } = require('../config');
-const { logger } = require('../logger')
+const logger = require('../logger')
 
 const keyPath = process.env.TEMPORAL_TLS_KEY_PATH;
 const certPath = process.env.TEMPORAL_TLS_CERT_PATH;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds timestamps to console `log`, `warn` and `error`
Logs and error sample:

``` bash
[user0@user0 w]$ npm run dev

> temporal-web@1.10.0 dev /home/user0/w
> NODE_ENV=development node server.js

establishing insecure connection...
ℹ ｢hot｣: webpack: Compiling...
[2021-07-19T18:27:01.044Z] temporal-web up and listening on port 8088
[2021-07-19T18:27:01.044Z] webpack is compiling...
...

ℹ ｢wdm｣: Compiled successfully.
ℹ ｢hot｣: WebSocket Client Connected
[2021-07-19T18:30:07.920Z]  Error: CUSTOM ERROR
    at TemporalClient.listNamespaces (/home/user0/w/server/temporal-client/temporal-client.js:79:9)
    at async Proxy.<anonymous> (/home/user0/w/server/temporal-client/with-error-converter.js:30:18)
    at async /home/user0/w/server/routes.js:19:14
    at async initialize (/home/user0/w/server/auth/index.js:11:5)
    at async session (/home/user0/w/node_modules/koa-session/index.js:41:7)
    at async bodyParser (/home/user0/w/node_modules/koa-bodyparser/index.js:95:5)
    at async /home/user0/w/server/index.js:45:9
```

## Why?
<!-- Tell your future self why have you made these changes -->
Helps investigating logs

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
