### PR TITLE
Add web tls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Optional TLS configuration variables:
 | TEMPORAL_TLS_ENABLE_HOST_VERIFICATION | Enables verification of the server certificate                      | true    |
 | TEMPORAL_TLS_SERVER_NAME              | Target server that is used for TLS host verification                |         |
 | TEMPORAL_TLS_REFRESH_INTERVAL         | How often to refresh TLS Certs, seconds                             | 0       |
+| TEMPORAL_WEB_USE_HTTPS                | Enables HTTPS when viewing the temporal web UI in a browser         | false   |
+| TEMPORAL_WEB_TLS_CERT_PATH            | Certificate used to support HTTPS in the temporal web UI            |         |
+| TEMPORAL_WEB_TLS_KEY_PATH             | Private key for supporting HTTPS in the temporal web UI             |         |
 
 * To enable mutual TLS, you need to specify `TEMPORAL_TLS_KEY_PATH` and `TEMPORAL_TLS_CERT_PATH`.
 * For server-side TLS you need to specify only `TEMPORAL_TLS_CA_PATH`.

--- a/server.js
+++ b/server.js
@@ -1,10 +1,23 @@
-var app = require('./server/index'),
-    port = Number(process.env.TEMPORAL_WEB_PORT) || 8088,
-    production = process.env.NODE_ENV === 'production'
+const app = require('./server/index'),
+  port = Number(process.env.TEMPORAL_WEB_PORT) || 8088,
+  production = process.env.NODE_ENV === 'production',
+  sslEnabled = process.env.TEMPORAL_WEB_USE_HTTPS || false;
 
-app.init().listen(port)
+if (sslEnabled) {
+  const https = require('https');
+  const fs = require('fs');
+  const options = {
+    key: fs.readFileSync(process.env.TEMPORAL_WEB_TLS_KEY_PATH),
+    cert: fs.readFileSync(process.env.TEMPORAL_WEB_TLS_CERT_PATH),
+  };
 
-console.log('temporal-web up and listening on port ' + port)
+  https.createServer(options, app.init().callback()).listen(port);
+} else {
+  app.init().listen(port);
+}
+
+console.log('temporal-web up and listening on port ' + port);
+
 if (!production) {
-  console.log('webpack is compiling...')
+  console.log('webpack is compiling...');
 }

--- a/server.js
+++ b/server.js
@@ -3,16 +3,19 @@ const app = require('./server/index'),
   production = process.env.NODE_ENV === 'production',
   sslEnabled = process.env.TEMPORAL_WEB_USE_HTTPS || false;
 
-if (sslEnabled) {
+if (sslEnabled === "true") {
   const https = require('https');
   const fs = require('fs');
-  const options = {
-    key: fs.readFileSync(process.env.TEMPORAL_WEB_TLS_KEY_PATH),
-    cert: fs.readFileSync(process.env.TEMPORAL_WEB_TLS_CERT_PATH),
-  };
 
-  https.createServer(options, app.init().callback()).listen(port);
+  console.log('temporal-web ssl is enabled');
+  https.createServer({
+      key: fs.readFileSync(process.env.TEMPORAL_WEB_TLS_KEY_PATH),
+      cert: fs.readFileSync(process.env.TEMPORAL_WEB_TLS_CERT_PATH),
+    }, 
+    app.init().callback()
+  ).listen(port);
 } else {
+  console.log('temporal-web ssl is not enabled');
   app.init().listen(port);
 }
 


### PR DESCRIPTION
PR to add support for HTTPS in temporal web.

See: 
https://community.temporal.io/t/enable-end-to-end-tls-https-to-container-in-temporal-web/2817/9

<!--- For ALL Contributors 👇 -->

## What was changed
Updated server.js to include support for running the koa app using HTTPS or HTTP based on environment variables. Solution was based on [koa docs](https://koajs.com/#app-listen-). Note it does not implement the multiple port support as the koa docs mention as I figured that was overkill. It's just an either HTTPS or HTTP on the configured port, not both.

## Why?
Add support for end-to-end TLS support

## Checklist

1. How was this tested:
Built and tested locally using ```npm run dev```, also built docker container and tested in an EKS cluster. 

2. Any docs updates needed?
Added 3 new ENV vars available for temporal web to control TLS for web: 

- TEMPORAL_WEB_USE_HTTPS: true == enable TLS, false == disable TLS, default == false
- TEMPORAL_WEB_TLS_KEY_PATH: path to the private key to use for HTTPS connectivity into temporal web
- TEMPORAL_WEB_TLS_CERT_PATH: path to the certificate to use for HTTPS connectivity into temporal web
