### PR TITLE
Link to new executions for more event types

### DIFF
--- a/client/routes/workflow/helpers/get-summary-workflow-status.js
+++ b/client/routes/workflow/helpers/get-summary-workflow-status.js
@@ -14,22 +14,26 @@ const getSummaryWorkflowStatus = ({
     ).toLowerCase();
   }
 
-  if (workflowCompletedEvent.eventType === 'WorkflowExecutionContinuedAsNew') {
+  const text = workflowCompletedEvent.eventType
+    .replace('WorkflowExecution', '')
+    .toLowerCase()
+    .replace('continuedasnew', 'continued-as-new');
+
+  // Any of {Completed,Failed,TimedOut,ContinuedAsNew} can have this field:
+  if (workflowCompletedEvent.details && workflowCompletedEvent.details.newExecutionRunId) {
     return {
-      to: {
+      text: text,
+      status: text,
+      next: {
         name: 'workflow/summary',
         params: {
           runId: workflowCompletedEvent.details.newExecutionRunId,
         },
       },
-      text: 'Continued As New',
-      status: 'continued-as-new',
     };
   }
 
-  return workflowCompletedEvent.eventType
-    .replace('WorkflowExecution', '')
-    .toLowerCase();
+  return text;
 };
 
 export default getSummaryWorkflowStatus;

--- a/client/routes/workflow/helpers/get-summary-workflow-status.spec.js
+++ b/client/routes/workflow/helpers/get-summary-workflow-status.spec.js
@@ -53,22 +53,22 @@ describe('getSummaryWorkflowStatus', () => {
       };
     });
 
-    it('should return an object with to.name = "workflow/summary".', () => {
+    it('should return an object with next.name = "workflow/summary".', () => {
       const output = getSummaryWorkflowStatus(event);
 
-      expect(output.to.name).toEqual('workflow/summary');
+      expect(output.next.name).toEqual('workflow/summary');
     });
 
-    it('should return an object with to.params.runId.', () => {
+    it('should return an object with next.params.runId.', () => {
       const output = getSummaryWorkflowStatus(event);
 
-      expect(output.to.params.runId).toEqual('newExecutionRunIdValue');
+      expect(output.next.params.runId).toEqual('newExecutionRunIdValue');
     });
 
-    it('should return an object with text = "Continued As New".', () => {
+    it('should return an object with text = "continued-as-new".', () => {
       const output = getSummaryWorkflowStatus(event);
 
-      expect(output.text).toEqual('Continued As New');
+      expect(output.text).toEqual('continued-as-new');
     });
 
     it('should return an object with status = "continued-as-new".', () => {
@@ -78,16 +78,55 @@ describe('getSummaryWorkflowStatus', () => {
     });
   });
 
+  describe('When passed an event with workflowCompletedEvent.eventType === "WorkflowExecutionCompleted" and workflowCompletedEvent.details.newExecutionRunId is defined', () => {
+    let event;
+
+    beforeEach(() => {
+      event = {
+        workflowCompletedEvent: {
+          eventType: 'WorkflowExecutionCompleted',
+          details: {
+            newExecutionRunId: 'newExecutionRunIdValue',
+          },
+        },
+      };
+    });
+
+    it('should return an object with next.name = "workflow/summary".', () => {
+      const output = getSummaryWorkflowStatus(event);
+
+      expect(output.next.name).toEqual('workflow/summary');
+    });
+
+    it('should return an object with next.params.runId.', () => {
+      const output = getSummaryWorkflowStatus(event);
+
+      expect(output.next.params.runId).toEqual('newExecutionRunIdValue');
+    });
+
+    it('should return an object with text = "completed".', () => {
+      const output = getSummaryWorkflowStatus(event);
+
+      expect(output.text).toEqual('completed');
+    });
+
+    it('should return an object with status = "completed".', () => {
+      const output = getSummaryWorkflowStatus(event);
+
+      expect(output.status).toEqual('completed');
+    });
+  });
+
   describe('When passed an workflowCompletedEvent.eventType !== "WorkflowExecutionContinuedAsNew"', () => {
     it('should return workflowCompletedEvent.eventType without WorkflowExecution and in lower case.', () => {
       const event = {
         workflowCompletedEvent: {
-          eventType: 'NotWorkflowExecutionContinuedAsNew',
+          eventType: 'WorkflowExecutionSomethingElse',
         },
       };
       const output = getSummaryWorkflowStatus(event);
 
-      expect(output).toEqual('notcontinuedasnew');
+      expect(output).toEqual('somethingelse');
     });
   });
 });

--- a/client/routes/workflow/helpers/summarize-events.js
+++ b/client/routes/workflow/helpers/summarize-events.js
@@ -116,7 +116,18 @@ const summaryExtractors = {
 
     return summary;
   },
-  WorkflowExecutionFailed: d => ({ message: d.failure?.message }),
+  WorkflowExecutionCompleted: d => ({
+    result: d.result,
+    newExecutionRunId: d.newExecutionRunId || undefined,
+  }),
+  WorkflowExecutionFailed: d => ({
+    message: d.failure?.message,
+    newExecutionRunId: d.newExecutionRunId || undefined,
+  }),
+  WorkflowExecutionTimedOut: d => ({
+    retryState: d.retryState,
+    newExecutionRunId: d.newExecutionRunId || undefined,
+  }),
   WorkflowTaskFailed: d => ({ message: d.failure?.message }),
   ChildWorkflowExecutionFailed: d => ({ message: d.failure?.message }),
 };

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -72,12 +72,10 @@
         <dd>
           <bar-loader v-if="wfStatus === 'running'" />
           <span v-if="typeof wfStatus === 'string'">{{ wfStatus }}</span>
-          <router-link
-            v-if="wfStatus !== undefined && wfStatus.to"
-            :to="wfStatus.to"
-          >
+          <span v-if="wfStatus !== undefined && wfStatus.next">
             {{ wfStatus.text }}
-          </router-link>
+            <router-link :to="wfStatus.next">(next)</router-link>
+          </span>
         </dd>
       </div>
       <div class="workflow-id" data-cy="workflow-id">
@@ -286,6 +284,8 @@ section.workflow-summary
   .workflow-status
     dd
       text-transform capitalize
+      a
+        text-transform none
     &[data-status="completed"] dd
       color uber-green
     &[data-status="failed"] dd


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

After https://github.com/temporalio/temporal/pull/1866 (to be released in 1.13), more event types can have a link to a new execution. This exposes them in the status summary, and also history events table summary mode. The field name is the same for all events, so not much else had to change.

## Why?
<!-- Tell your future self why have you made these changes -->

So that users can still easily navigate to the next execution after a retry or cron.

## Checklist
<!--- add/delete as needed --->

2. How was this tested: Updated unit tests
