### PR TITLE
Make header namespace link always clickable

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -291,8 +291,6 @@ header.top-bar
       margin-right spacing
     a:hover
       color lighten(uber-blue, 15%)
-    .router-link-active
-      pointer-events none
     span
       cursor pointer
       transition smooth-transition


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Makes the namespace link always clickable:

![image](https://user-images.githubusercontent.com/11838981/133702691-aa0ba60c-9584-4ef3-9033-68b5d2b541e1.png)

## Why?
<!-- Tell your future self why have you made these changes -->

Previously for paths = `/namespace/<name>/workflows`, the link would become disabled. This behavior was reported few times as confusing (and personally found this rather confusing too)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

manually checked that the link is active for different paths, including `/namespace/<name>/workflows`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
