### PR TITLE
Add server security notion in readme and remove Google OIDC notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enabl
       providers:
           - label: 'Auth0 oidc'                        # for internal use; in future may expose as button text
             type: oidc                                  # for futureproofing; only oidc is supported today
-            issuer: https://myorg.us.auth0.com/
+            issuer: https://myorg.us.auth0.com
             client_id: xxxxxxxxxxxxxxxxxxxx
             client_secret: xxxxxxxxxxxxxxxxxxxx
             scope: openid profile email

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Setting `TEMPORAL_TLS_REFRESH_INTERVAL` will make the TLS certs reload every N s
 
 > ⚠️ This is currently a beta feature, [please report any and all issues to us!](https://github.com/temporalio/web/issues/new)
 
-**Note** For proper security, your server needs to be secured as well and validate the JWT tokens that Temporal Web will be sending to server once users are authenticated. See https://docs.temporal.io/docs/server/security/#authorization for details
+**Note** For proper security, your server needs to be secured as well and validate the JWT tokens that Temporal Web will be sending to server once users are authenticated. See [security docs](https://docs.temporal.io/docs/server/security/#authorization) for details
 
 Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enable it in 2 steps:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Setting `TEMPORAL_TLS_REFRESH_INTERVAL` will make the TLS certs reload every N s
 
 > ⚠️ This is currently a beta feature, [please report any and all issues to us!](https://github.com/temporalio/web/issues/new)
 
+**Note** For proper security, your server needs to be secured as well and validate the JWT tokens that Temporal Web will be sending to server once users are authenticated. See https://docs.temporal.io/docs/server/security/#authorization for details
+
 Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enable it in 2 steps:
 
 1. Edit the `server/config.yml` file:
@@ -71,13 +73,13 @@ Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enabl
     auth:
       enabled: true # Temporal Web checks this first before reading your provider config
       providers:
-          - label: 'google oidc'                        # for internal use; in future may expose as button text
+          - label: 'Auth0 oidc'                        # for internal use; in future may expose as button text
             type: oidc                                  # for futureproofing; only oidc is supported today
-            issuer: https://accounts.google.com
-            client_id: xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
-            client_secret: xxxxxxxxxxxxxxxxxxxxxxx
+            issuer: https://myorg.us.auth0.com/
+            client_id: xxxxxxxxxxxxxxxxxxxx
+            client_secret: xxxxxxxxxxxxxxxxxxxx
             scope: openid profile email
-            audience: temporal # identifier of the audience for an issued token (optional)
+            audience: # identifier of the audience for an issued token (optional)
             callback_base_uri: http://localhost:8088
             pass_id_token: false # adds ID token as 'authorization-extras' header with every request to server
     ```
@@ -101,8 +103,6 @@ Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enabl
     In future, multiple Oauth providers may be supported, however for now we only read the first Oauth provider under the `providers` key above.
 
     Common Oauth Providers and their docs:
-
-    - Google: https://developers.google.com/identity/protocols/oauth2/openid-connect
     - Auth0: https://auth0.com/docs/protocols/configure-okta-as-oauth2-identity-provider
     - Okta: https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard_OIDC.htm
         <details>

--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ Setting `TEMPORAL_TLS_REFRESH_INTERVAL` will make the TLS certs reload every N s
 
 ### Configuring Authentication (optional)
 
-> ⚠️ This is currently a beta feature, [please report any and all issues to us!](https://github.com/temporalio/web/issues/new)
-
 **Note** For proper security, your server needs to be secured as well and validate the JWT tokens that Temporal Web will be sending to server once users are authenticated. See [security docs](https://docs.temporal.io/docs/server/security/#authorization) for details
 
 Since v1.3, Temporal Web offers optional OAuth SSO authentication. You can enable it in 2 steps:

--- a/server/config.yml
+++ b/server/config.yml
@@ -2,12 +2,13 @@ auth:
   enabled: false
   providers:
       # # example provider
-      # - label: 'google oidc'                        # for internal use; in future may expose as button text
+      # - label: 'Auth0 oidc'                        # for internal use; in future may expose as button text
       #   type: oidc                                  # for futureproofing; only oidc is supported today
-      #   issuer: https://accounts.google.com
-      #   client_id: xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
-      #   client_secret: xxxxxxxxxxxxxxxxxxxxxxx
+      #   issuer: https://myorg.us.auth0.com/
+      #   client_id: xxxxxxxxxxxxxxxxxxxx
+      #   client_secret: xxxxxxxxxxxxxxxxxxxx
       #   scope: openid profile email
+      #   audience:
       #   callback_base_uri: http://localhost:8088
       #   pass_id_token: false
 # for more info see docs: https://github.com/temporalio/web#configuring-authentication-optional

--- a/server/config.yml
+++ b/server/config.yml
@@ -4,7 +4,7 @@ auth:
       # # example provider
       # - label: 'Auth0 oidc'                        # for internal use; in future may expose as button text
       #   type: oidc                                  # for futureproofing; only oidc is supported today
-      #   issuer: https://myorg.us.auth0.com/
+      #   issuer: https://myorg.us.auth0.com
       #   client_id: xxxxxxxxxxxxxxxxxxxx
       #   client_secret: xxxxxxxxxxxxxxxxxxxx
       #   scope: openid profile email


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

* Added server security notion and a link to the security docs
* Switched to Auth0 as sample values for OIDC auth instead of Google
* Removed authentication beta notion from readme

## Why?
<!-- Tell your future self why have you made these changes -->

* users would enable auth on the Web though wouldn't add JWT tokens validation on the server side, having a wrong impressions of secured setup
* Google OIDC for base @google.com accounts doesn't seem to have/make it easy to configure permissions. Preferred Auth0 as samples

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
