### PR TITLE
fix subpath for homepage link

### DIFF
--- a/client/components/namespace-navigation.vue
+++ b/client/components/namespace-navigation.vue
@@ -61,6 +61,8 @@ import { stringify } from 'friendly-querystring';
 import { getKeyValuePairs, mapNamespaceDescription } from '~helpers';
 import { DetailList } from '~components';
 
+const PUBLIC_PATH = process.env.TEMPORAL_WEB_ROOT_PATH || '/';
+
 const validationMessages = {
   valid: d => `${d} exists`,
   invalid: d => `${d} does not exist`,
@@ -111,7 +113,7 @@ export default {
       }
     },
     namespaceLink(d) {
-      return `/namespaces/${d}/workflows?${stringify(
+      return `${PUBLIC_PATH}namespaces/${d}/workflows?${stringify(
         this.$router.currentRoute.query
       )}`;
     },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add the subpath for the home page link

## Why?
once build the code with `TEMPORAL_WEB_ROOT_PATH`, all the link should have the `subpath` as prefix.
![image](https://user-images.githubusercontent.com/17842462/151308082-60401088-4a6e-4be1-a6d2-34956ae2ce90.png)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
NA

2. How was this tested:
Manual test

3. Any docs updates needed?
NA
