### PR TITLE
Add remote data encoder support.

### DIFF
--- a/client/features/data-conversion.js
+++ b/client/features/data-conversion.js
@@ -1,6 +1,40 @@
 import WebSocketAsPromised from 'websocket-as-promised';
 
-export const convertEventPayloads = async (events, port) => {
+export const convertEventPayloadsWithRemoteEncoder = async (events, endpoint) => {
+  const headers = { 'Content-Type': 'application/json' };
+  const requests = [];
+
+  events.forEach(event => {
+    let payloads = [];
+
+    if (event.details.input) {
+      payloads = event.details.input.payloads;
+    } else if (event.details.result) {
+      payloads = event.details.result.payloads;
+    }
+
+    payloads.forEach((payload, i) => {
+      requests.push(
+        fetch(`${endpoint}/decode`, { method: 'POST', headers: headers, body: JSON.stringify(payload) })
+        .then((response) => response.json())
+        .then((decodedPayload) => {
+          let data = window.atob(decodedPayload.data);
+          try {
+            payloads[i] = JSON.parse(data);
+          } catch {
+            payloads[i] = data;
+          }
+        })
+      )
+    });
+  });
+
+  await Promise.allSettled(requests)
+
+  return events;
+};
+
+export const convertEventPayloadsWithWebsocket = async (events, port) => {
   const sock = new WebSocketAsPromised(`ws://localhost:${port}/`, {
     packMessage: data => JSON.stringify(data),
     unpackMessage: data => JSON.parse(data),

--- a/client/main.js
+++ b/client/main.js
@@ -182,6 +182,16 @@ const routeOpts = {
       },
     },
     {
+      name: 'remote-data-encoder',
+      path: '/remote-data-encoder/:endpoint',
+      beforeEnter: async (to, _from, next) => {
+        await http.global.post(
+          `/api/web-settings/remote-data-encoder/${encodeURIComponent(to.params.endpoint)}`
+        );
+        next('/');
+      },
+    },
+    {
       name: 'namespaces-redirect',
       path: '/namespace/*',
       redirect: '/namespaces/*',

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -80,7 +80,7 @@ import {
 import { NOTIFICATION_TYPE_ERROR } from '~constants';
 import { getErrorMessage } from '~helpers';
 import { NavigationBar, NavigationLink } from '~components';
-import { convertEventPayloads } from '~features/data-conversion';
+import { convertEventPayloadsWithWebsocket, convertEventPayloadsWithRemoteEncoder } from '~features/data-conversion';
 
 export default {
   data() {
@@ -139,7 +139,7 @@ export default {
       )}/${encodeURIComponent(runId)}`;
     },
     historyUrl() {
-      const rawPayloads = this.webSettings?.dataConverter?.port
+      const rawPayloads = (this.webSettings?.dataConverter?.port || this.webSettings?.remoteDataEncoder?.endpoint)
         ? '&rawPayloads=true'
         : '';
       const historyUrl = `${this.baseAPIURL}/history?waitForNewEvent=true${rawPayloads}`;
@@ -205,21 +205,35 @@ export default {
         })
         .then(events => {
           const port = this.webSettings?.dataConverter?.port;
+          const endpoint = this.webSettings?.remoteDataEncoder?.endpoint;
 
-          if (port == undefined) {
-            return events;
+          if (port !== undefined) {
+            return convertEventPayloadsWithWebsocket(events, port).catch(error => {
+              console.error(error);
+
+              this.$emit('onNotification', {
+                message: getErrorMessage(error),
+                type: NOTIFICATION_TYPE_ERROR,
+              });
+
+              return events;
+            });
           }
 
-          return convertEventPayloads(events, port).catch(error => {
-            console.error(error);
+          if (endpoint !== undefined) {
+            return convertEventPayloadsWithRemoteEncoder(events, endpoint).catch(error => {
+              console.error(error);
 
-            this.$emit('onNotification', {
-              message: getErrorMessage(error),
-              type: NOTIFICATION_TYPE_ERROR,
+              this.$emit('onNotification', {
+                message: getErrorMessage(error),
+                type: NOTIFICATION_TYPE_ERROR,
+              });
+
+              return events;
             });
+          }
 
-            return events;
-          });
+          return events;
         })
         .then(events => {
           const shouldHighlightEventId =

--- a/server/routes.js
+++ b/server/routes.js
@@ -350,11 +350,17 @@ router.post('/api/web-settings/data-converter/:port', async (ctx) => {
   ctx.status = 200;
 });
 
+router.post('/api/web-settings/remote-data-encoder/:endpoint', async (ctx) => {
+  ctx.session.remoteDataEncoder = { endpoint: ctx.params.endpoint };
+  ctx.status = 200;
+});
+
 router.get('/api/web-settings', async (ctx) => {
   const routing = await getRoutingConfig();
   const { enabled } = await getAuthConfig();
   const permitWriteApi = isWriteApiPermitted();
   const dataConverter = ctx.session.dataConverter;
+  const remoteDataEncoder = ctx.session.remoteDataEncoder;
 
   const auth = { enabled }; // only include non-sensitive data
 
@@ -363,6 +369,7 @@ router.get('/api/web-settings', async (ctx) => {
     auth,
     permitWriteApi,
     dataConverter,
+    remoteDataEncoder,
   };
 });
 


### PR DESCRIPTION
## What was changed

Added support for remote data encoders. This is a new API currently under review at https://github.com/temporalio/sdk-go/pull/717. This PR should not be merged until the SDK PR is merged.

For this first iteration only basic auth is supported via https://user:password@remote-encoder-url.com, oauth for the remote encoder is not supported.

## Why?

This allows the web UI to make use of a shared remote encoder rather than needing to run `tctl dc web` command locally. In this deployment model developers don't need to use the tctl plugin system or have access to the encryption keys on their development machine.

## Checklist

1. How was this tested:
Tested on my integration branch of backgroud-checks which has a full encryption data converter setup for a sample Temporal application.

2. Any docs updates needed?
Yes, documentation will be needed to explain how to deploy such a system.