### PR TITLE
Data encoder config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Set these environment variables if you need to change their defaults
 | TEMPORAL_SESSION_SECRET       | Secret used to hash the session with HMAC                         | "ensure secret in production" |
 | TEMPORAL_EXTERNAL_SCRIPTS     | Additional JavaScript tags to serve in the UI                     |                               |
 | TEMPORAL_GRPC_MAX_MESSAGE_LENGTH | gRPC max message length (bytes)                                | 4194304 (4mb)                 |
+| TEMPORAL_DATA_ENCODER_ENDPOINT | Remote Data Encoder Endpoint, explained below                    |                               |
 
 <details>
 <summary>
@@ -58,6 +59,22 @@ By default we will also verify your server `hostname`, matching it to `TEMPORAL_
 Setting `TEMPORAL_TLS_REFRESH_INTERVAL` will make the TLS certs reload every N seconds.
 
 </details>
+
+### Configuring Remote Data Encoder (optional)
+
+If you are using a data converter on your workers to encrypt Temporal Payloads you may wish to deploy a remote data encoder so that your users can see the unencrypted Payloads while using Temporal Web. The documentation for the Temporal SDK you are using for your application should include documentation on how to build a remote data encoder. Please let us know if this is not the case. Once you have a remote data encoder running you can configure Temporal Web to use it to decode Payloads for a user in 2 ways:
+
+1. Edit the `server/config.yml` file:
+
+    ```yaml
+    data_encoder:
+      endpoint: https://remote_encoder.myorg.com
+    ```
+2. Set the environment variable TEMPORAL_DATA_ENCODER_ENDPOINT to the URL for your remote data encoder. This is often a more convenient option when running Temporal Web in a docker container.
+
+Temporal Web will then configure it's UI to decode Payloads as appropriate via the remote data encoder.
+
+Please note that requests to the remote data encoder will be made from the user's browser directly, not via Temporal Web's server. This means that the Temporal Web server will never see the decoded Payloads and does not need to be able to connect to the remote data encoder. This allows using remote data encoders on internal and secure networks while using an externally hosted Temporal Web instance, such that provided by Temporal Cloud.
 
 ### Configuring Authentication (optional)
 

--- a/client/features/data-conversion.js
+++ b/client/features/data-conversion.js
@@ -13,6 +13,10 @@ export const convertEventPayloadsWithRemoteEncoder = async (events, endpoint) =>
       payloadsWrapper = event.details.result;
     }
 
+    if (!payloadsWrapper) {
+      continue;
+    }
+
     requests.push(
       fetch(`${endpoint}/decode`, { method: 'POST', headers: headers, body: JSON.stringify(payloadsWrapper) })
         .then((response) => response.json())

--- a/client/features/data-conversion.js
+++ b/client/features/data-conversion.js
@@ -14,7 +14,7 @@ export const convertEventPayloadsWithRemoteEncoder = async (events, endpoint) =>
     }
 
     if (!payloadsWrapper) {
-      continue;
+      return;
     }
 
     requests.push(

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -139,7 +139,7 @@ export default {
       )}/${encodeURIComponent(runId)}`;
     },
     historyUrl() {
-      const rawPayloads = (this.webSettings?.dataConverter?.port || this.webSettings?.remoteDataEncoder?.endpoint)
+      const rawPayloads = (this.webSettings?.dataConverter?.port || this.webSettings?.dataEncoder?.endpoint)
         ? '&rawPayloads=true'
         : '';
       const historyUrl = `${this.baseAPIURL}/history?waitForNewEvent=true${rawPayloads}`;
@@ -205,7 +205,7 @@ export default {
         })
         .then(events => {
           const port = this.webSettings?.dataConverter?.port;
-          const endpoint = this.webSettings?.remoteDataEncoder?.endpoint;
+          const endpoint = this.webSettings?.dataEncoder?.endpoint;
 
           if (port !== undefined) {
             return convertEventPayloadsWithWebsocket(events, port).catch(error => {

--- a/server/config.yml
+++ b/server/config.yml
@@ -16,3 +16,7 @@ auth:
 routing:
   default_to_namespace: # internal use only
   issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums
+
+# data_encoder:
+  # Remote Data Encoder Endpoint
+  # endpoint: https://remote_encoder.myorg.com

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -4,6 +4,7 @@ const yaml = require('js-yaml');
 const logger = require('../logger');
 
 const configPath = process.env.TEMPORAL_CONFIG_PATH || './server/config.yml';
+const dataEncoderEndpoint = process.env.TEMPORAL_DATA_ENCODER_ENDPOINT;
 
 const readConfigSync = () => {
   const cfgContents = readFileSync(configPath, {
@@ -26,6 +27,18 @@ const getAuthConfig = async () => {
   }
   return auth;
 };
+
+const getDataEncoderConfig = async () => {
+  let { data_encoder } = await readConfig();
+
+  // Data encoder endpoint from the environment takes precedence over
+  // configuration file value.
+  const dataEncoderConfig = {
+    endpoint: dataEncoderEndpoint || data_encoder?.endpoint
+  }
+
+  return dataEncoderConfig;
+}
 
 const getRoutingConfig = async () => {
   const { routing } = await readConfig();
@@ -71,6 +84,7 @@ logger.log(
 
 module.exports = {
   getAuthConfig,
+  getDataEncoderConfig,
   getRoutingConfig,
   getTlsConfig,
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -3,7 +3,7 @@ const Router = require('koa-router'),
   moment = require('moment'),
   losslessJSON = require('lossless-json'),
   { isWriteApiPermitted } = require('./utils'),
-  { getAuthConfig, getRoutingConfig } = require('./config'),
+  { getAuthConfig, getRoutingConfig, getEncoderConfig } = require('./config'),
   authRoutes = require('./routes-auth'),
   { getTemporalClient: tClient } = require('./temporal-client-provider');
 
@@ -351,16 +351,23 @@ router.post('/api/web-settings/data-converter/:port', async (ctx) => {
 });
 
 router.post('/api/web-settings/remote-data-encoder/:endpoint', async (ctx) => {
-  ctx.session.remoteDataEncoder = { endpoint: ctx.params.endpoint };
+  ctx.session.dataEncoderEndpoint = { endpoint: ctx.params.endpoint };
   ctx.status = 200;
 });
 
 router.get('/api/web-settings', async (ctx) => {
   const routing = await getRoutingConfig();
   const { enabled } = await getAuthConfig();
+  const { dataEncoder } = await getEncoderConfig();
   const permitWriteApi = isWriteApiPermitted();
   const dataConverter = ctx.session.dataConverter;
-  const remoteDataEncoder = ctx.session.remoteDataEncoder;
+  const dataEncoderEndpoint = ctx.session.dataEncoderEndpoint;
+  
+  // Encoder endpoint from the session has higher priority than global config.
+  // This is to allow for testing of new remote encoder endpoints.
+  if (dataEncoderEndpoint) {
+    dataEncoder.endpoint = dataEncoderEndpoint;
+  }
 
   const auth = { enabled }; // only include non-sensitive data
 
@@ -369,7 +376,7 @@ router.get('/api/web-settings', async (ctx) => {
     auth,
     permitWriteApi,
     dataConverter,
-    remoteDataEncoder,
+    dataEncoder,
   };
 });
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -351,7 +351,7 @@ router.post('/api/web-settings/data-converter/:port', async (ctx) => {
 });
 
 router.post('/api/web-settings/remote-data-encoder/:endpoint', async (ctx) => {
-  ctx.session.dataEncoderEndpoint = { endpoint: ctx.params.endpoint };
+  ctx.session.dataEncoder = { endpoint: ctx.params.endpoint };
   ctx.status = 200;
 });
 
@@ -361,12 +361,11 @@ router.get('/api/web-settings', async (ctx) => {
   const dataEncoder = await getDataEncoderConfig();
   const permitWriteApi = isWriteApiPermitted();
   const dataConverter = ctx.session.dataConverter;
-  const dataEncoderEndpoint = ctx.session.dataEncoderEndpoint;
   
   // Encoder endpoint from the session has higher priority than global config.
   // This is to allow for testing of new remote encoder endpoints.
-  if (dataEncoderEndpoint) {
-    dataEncoder.endpoint = dataEncoderEndpoint;
+  if (ctx.session.dataEncoder?.endpoint) {
+    dataEncoder.endpoint = ctx.session.dataEncoder.endpoint;
   }
 
   const auth = { enabled }; // only include non-sensitive data

--- a/server/routes.js
+++ b/server/routes.js
@@ -3,7 +3,7 @@ const Router = require('koa-router'),
   moment = require('moment'),
   losslessJSON = require('lossless-json'),
   { isWriteApiPermitted } = require('./utils'),
-  { getAuthConfig, getRoutingConfig, getEncoderConfig } = require('./config'),
+  { getAuthConfig, getRoutingConfig, getDataEncoderConfig } = require('./config'),
   authRoutes = require('./routes-auth'),
   { getTemporalClient: tClient } = require('./temporal-client-provider');
 
@@ -358,7 +358,7 @@ router.post('/api/web-settings/remote-data-encoder/:endpoint', async (ctx) => {
 router.get('/api/web-settings', async (ctx) => {
   const routing = await getRoutingConfig();
   const { enabled } = await getAuthConfig();
-  const { dataEncoder } = await getEncoderConfig();
+  const dataEncoder = await getDataEncoderConfig();
   const permitWriteApi = isWriteApiPermitted();
   const dataConverter = ctx.session.dataConverter;
   const dataEncoderEndpoint = ctx.session.dataEncoderEndpoint;


### PR DESCRIPTION

## What was changed
Refactored the remote data encoder code a little to be more consistent with terms. Also added some documentation around the setup of such a system, although this should be improved and centralised later.

## Why?
This allows users to configure a remote data encoder endpoint globally for the Temporal Web instance rather than relying on per-session settings as was previously the case. Given remote data encoders will be deployed and shared it does not make sense to require per-session settings for every user.

## Checklist

1. How was this tested:
Tested using my background-checks integration branch.

3. Any docs updates needed?
Yes, docs will need to involve as more SDKs add support for remote data encoding and we add a central page that documents the setup as a whole.