### PR TITLE
Show an error key for payloads when remote decoder fails.

### DIFF
--- a/client/features/data-conversion.js
+++ b/client/features/data-conversion.js
@@ -31,6 +31,11 @@ export const convertEventPayloadsWithRemoteEncoder = async (events, endpoint) =>
             }  
           });
         })
+        .catch(() => {
+          payloadsWrapper.payloads.forEach((payload) => {
+            payload.error = "Could not decode payload, remote decoder returned an error."
+          })
+        })
     )
   })
 


### PR DESCRIPTION
## What was changed
Add an error message to payloads when remote decoding fails.

## Why?
This should make it more obvious why payloads aren't being decrypted when a user expected them to be.