### PR TITLE
Support codec endpoint templating and more flexible codecs

### DIFF
--- a/client/features/data-conversion.js
+++ b/client/features/data-conversion.js
@@ -25,11 +25,13 @@ export const convertEventPayloadsWithRemoteEncoder = async (events, endpoint) =>
           decodedPayloads.forEach((payload, i) => {
             let data = window.atob(payload.data);
             try {
-              payloadsWrapper.payloads[i] = JSON.parse(data);
+              decodedPayloads[i] = JSON.parse(data);
             } catch {
-              payloadsWrapper.payloads[i] = data;
+              decodedPayloads[i] = data;
             }  
           });
+
+          payloadsWrapper.payloads = decodedPayloads
         })
         .catch(() => {
           payloadsWrapper.payloads.forEach((payload) => {

--- a/client/features/data-conversion.js
+++ b/client/features/data-conversion.js
@@ -1,8 +1,9 @@
 import WebSocketAsPromised from 'websocket-as-promised';
 
-export const convertEventPayloadsWithRemoteEncoder = async (events, endpoint) => {
-  const headers = { 'Content-Type': 'application/json' };
+export const convertEventPayloadsWithRemoteEncoder = async (namespace, events, endpointTemplate) => {
+  const headers = { 'Content-Type': 'application/json', 'X-Namespace': namespace };
   const requests = [];
+  const endpoint = endpointTemplate.replaceAll('{namespace}', namespace);
 
   events.forEach(event => {
     let payloadsWrapper;

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -221,7 +221,7 @@ export default {
           }
 
           if (endpoint !== undefined) {
-            return convertEventPayloadsWithRemoteEncoder(events, endpoint).catch(error => {
+            return convertEventPayloadsWithRemoteEncoder(this.namespace, events, endpoint).catch(error => {
               console.error(error);
 
               this.$emit('onNotification', {


### PR DESCRIPTION
## What was changed
Support `{namespace}` templating in endpoint URL and send X-Namespace header. Don't assume that the payload count returned from the codec server will match what we sent.

## Why?
This allows for URL separation of encoders for different namespaces as encouraged by our sample code server. This is inline with the tctl support in https://github.com/temporalio/tctl/pull/161.

Also no longer assume that payload count will be consistent before/after decoding as some codecs may benefit from mapping multiple payloads into one (for example, better compression ratios).

## Checklist

1. How was this tested:
Tested against the remote codec server in samples-go.
