### PR TITLE
set font for workflow id and link to be monospaced

### DIFF
--- a/client/components/workflows-grid.vue
+++ b/client/components/workflows-grid.vue
@@ -127,8 +127,10 @@ paged-grid()
 
     &.col-id
       flex-basis: 400px;
+      font-family: monospace;
     &.col-link
       flex-basis: 400px;
+      font-family: monospace;
     &.col-name
       flex-basis: 300px;
     &.col-status


### PR DESCRIPTION
## What was changed
set font for workflow id and link to be monospaced

## Why?
Having these monospaced will make it easier to read and compare rows
